### PR TITLE
Parse out Unit of Measure and Precision

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,9 +5,20 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
-    '97': 'stopped/closed/closing/open/opening',  # Barrier
-    '73': 'watt',  # Energy Meter
-    '11': 'unlocked/locked'  # Lock
+    '97': [  # Barrier
+        'stopped',
+        'closed',
+        'closing',
+        'open',
+        'opening'
+    ],
+    '73': [  # Energy Meter
+        'watt'
+    ],
+    '11': [  # Lock
+        'unlocked',
+        'locked'
+    ]
 }
 
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,9 +5,9 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
-    '97': 'stopped/closed/closing/open/opening',
-    '73': 'watt',
-    '11': 'unlocked/locked'
+    '97': 'stopped/closed/closing/open/opening',  # Barrier
+    '73': 'watt',  # Energy Meter
+    '11': 'unlocked/locked'  # Lock
 }
 
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -196,9 +196,12 @@ class Nodes(object):
                                 else:
                                     units = uom.split('/')
                                 dimmable = '%' in units
+                                if 'prec' in nprop[0].attributes:
+                                    prec = nprop[0].attributes['prec'].value
                                 nval = int(nval.replace(' ', '0'))
                             self.insert(nid, nname, nparent,
-                                        Node(self, nid, nval, nname, dimmable),
+                                        Node(self, nid, nval, nname, dimmable,
+                                             uom=units, prec=prec),
                                         ntype)
                         elif ntype == 'group':
                             mems = feature.getElementsByTagName('link')

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -206,7 +206,8 @@ class Nodes(object):
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value
-                                uom = nprop[0].attributes['uom'].value
+                                if 'uom' in nprop[0].attributes:
+                                    uom = nprop[0].attributes['uom'].value
                                 if uom in UNIT_OF_MEASURE:
                                     units = UNIT_OF_MEASURE[unit]
                                 else:

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,6 +5,7 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
+    '97': 'stopped/closed/closing/open/opening',
     '73': 'watt',
     '11': 'unlocked/locked'
 }

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -203,6 +203,8 @@ class Nodes(object):
                             nval = None
                             dimmable = False
                             nprop = feature.getElementsByTagName('property')
+                            uom = None
+                            prec = 0
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -209,7 +209,7 @@ class Nodes(object):
                                 if 'uom' in nprop[0].attributes:
                                     uom = nprop[0].attributes['uom'].value
                                 if uom in UNIT_OF_MEASURE:
-                                    units = UNIT_OF_MEASURE[unit]
+                                    units = UNIT_OF_MEASURE[uom]
                                 else:
                                     units = uom.split('/')
                                 dimmable = '%' in units

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -12,6 +12,10 @@ UNIT_OF_MEASURE = {
         'open',
         'opening'
     ],
+    '78': [  # Motion, etc.
+        'on',
+        'off'
+    ],
     '73': [  # Energy Meter
         'watt'
     ],

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -4,6 +4,11 @@ from .node import Node
 from time import sleep
 from xml.dom import minidom
 
+UNIT_OF_MEASURE = {
+    '73': 'watt',
+    '11': 'unlocked/locked'
+}
+
 
 class Nodes(object):
 
@@ -185,8 +190,12 @@ class Nodes(object):
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value
-                                dimmable = '%' in \
-                                    nprop[0].attributes['uom'].value
+                                uom = nprop[0].attributes['uom'].value
+                                if uom in UNIT_OF_MEASURE:
+                                    units = UNIT_OF_MEASURE[unit]
+                                else:
+                                    units = uom.split('/')
+                                dimmable = '%' in units
                                 nval = int(nval.replace(' ', '0'))
                             self.insert(nid, nname, nparent,
                                         Node(self, nid, nval, nname, dimmable),

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -23,11 +23,13 @@ class Node(object):
     status = Property(0)
     hasChildren = False
 
-    def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False):
+    def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
+                 uom=None):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
         self.name = name
+        self.uom = uom
         self._spoken = spoken
 
         self.status = nval

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -24,12 +24,13 @@ class Node(object):
     hasChildren = False
 
     def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
-                 uom=None):
+                 uom=None, prec=0):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
         self.name = name
         self.uom = uom
+        self.prec = prec
         self._spoken = spoken
 
         self.status = nval


### PR DESCRIPTION
There may be more uom codes than I have - but these are the ones that I know about.

Pull out the `uom` field and split by / character or use the dictionary for custom measurements (examples: Locks, Barrier, Energy Meter, etc.)

Pull out `prec` field for analog sensor precision - for example, energy meter has 2 units of precision, so 500.00 Watts comes through as `50000` - this will help consumers of the library to know where to place the decimal in the value dynamically.