### PR TITLE
Locks use a different command

### DIFF
--- a/PyISY/Connection.py
+++ b/PyISY/Connection.py
@@ -205,6 +205,11 @@ class Connection(object):
         response = self.request(req_url)
         return response
 
+    def nodeSecMd(self, nid, val=0):
+        req_url = self.compileURL(['nodes', nid, 'cmd', 'SECMD', val])
+        response = self.request(req_url)
+        return response
+
     # VARIABLES
     def getVariables(self):
         requests = [['vars', 'definitions', '1'],

--- a/PyISY/Connection.py
+++ b/PyISY/Connection.py
@@ -210,6 +210,26 @@ class Connection(object):
         response = self.request(req_url)
         return response
 
+    def nodeCliFS(self, nid, val=0):
+        req_url = self.compileURL(['nodes', nid, 'cmd', 'CLIFS', val])
+        response = self.request(req_url)
+        return response
+
+    def nodeCliMD(self, nid, val=0):
+        req_url = self.compileURL(['nodes', nid, 'cmd', 'CLIMD', val])
+        response = self.request(req_url)
+        return response
+
+    def nodeCliSPH(self, nid, val=0):
+        req_url = self.compileURL(['nodes', nid, 'cmd', 'CLISPH', val])
+        response = self.request(req_url)
+        return response
+
+    def nodeCliSPC(self, nid, val=0):
+        req_url = self.compileURL(['nodes', nid, 'cmd', 'CLISPC', val])
+        response = self.request(req_url)
+        return response
+
     # VARIABLES
     def getVariables(self):
         requests = [['vars', 'definitions', '1'],

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -4,27 +4,6 @@ from .node import Node
 from time import sleep
 from xml.dom import minidom
 
-UNIT_OF_MEASURE = {
-    '97': [  # Barrier
-        'stopped',
-        'closed',
-        'closing',
-        'open',
-        'opening'
-    ],
-    '78': [  # Motion, etc.
-        'on',
-        'off'
-    ],
-    '73': [  # Energy Meter
-        'watt'
-    ],
-    '11': [  # Lock
-        'unlocked',
-        'locked'
-    ]
-}
-
 
 class Nodes(object):
 
@@ -210,10 +189,7 @@ class Nodes(object):
                                 nval = nprop[0].attributes['value'].value
                                 if 'uom' in nprop[0].attributes:
                                     uom = nprop[0].attributes['uom'].value
-                                if uom in UNIT_OF_MEASURE:
-                                    units = UNIT_OF_MEASURE[uom]
-                                else:
-                                    units = uom.split('/')
+                                units = uom.split('/')
                                 dimmable = '%' in units
                                 if 'prec' in nprop[0].attributes:
                                     prec = nprop[0].attributes['prec'].value

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -245,18 +245,29 @@ class Nodes(object):
             else:
                 for feature in xmldoc.getElementsByTagName('node'):
                     nid = feature.attributes['id'].value
-                    nval = feature.getElementsByTagName('property')[0] \
-                        .attributes['value'].value
-                    nval = int(nval.replace(' ', '0'))
-                    dimmable = '%' in \
-                        feature.getElementsByTagName('property')[0] \
-                        .attributes['uom'].value
-                    if nid in self.nids:
-                        self.getByID(nid).status.update(nval, silent=True)
-                    else:
-                        self.insert(nid, ' ', None,
-                                    Node(self, nid, nval), 'node')
-                    self.getByID(nid).dimmable = dimmable
+                    nprop = feature.getElementsByTagName('property')
+                    for prop in nprop:
+                        uom = ''
+                        prop_type = prop.attributes['id'].value
+                        if 'uom' in prop.attributes:
+                            uom = prop.attributes['uom'].value
+                        units = uom.split('/')
+                        dimmable = '%' in units
+                        nval = prop.attributes['value'].value
+                        nval = int(nval.replace(' ', '0'))
+
+                        if prop_type == 'ST':
+                            id = nid
+                        else:
+                            id = '{}_{}'.format(nid)
+
+                        if id in self.nids:
+                            self.getByID(id).status.update(nval, silent=True)
+                        else:
+                            self.insert(id, ' ', None,
+                                        Node(self, id, nval), 'node')
+
+                        self.getById(id).dimmable = dimmable
 
                 self.parent.log.info('ISY Updated Nodes')
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,9 +5,20 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
-    '97': 'stopped/closed/closing/open/opening',  # Barrier
-    '73': 'watt',  # Energy Meter
-    '11': 'unlocked/locked'  # Lock
+    '97': [  # Barrier
+        'stopped',
+        'closed',
+        'closing',
+        'open',
+        'opening'
+    ],
+    '73': [  # Energy Meter
+        'watt'
+    ],
+    '11': [  # Lock
+        'unlocked',
+        'locked'
+    ]
 }
 
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,9 +5,9 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
-    '97': 'stopped/closed/closing/open/opening',
-    '73': 'watt',
-    '11': 'unlocked/locked'
+    '97': 'stopped/closed/closing/open/opening',  # Barrier
+    '73': 'watt',  # Energy Meter
+    '11': 'unlocked/locked'  # Lock
 }
 
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -196,9 +196,12 @@ class Nodes(object):
                                 else:
                                     units = uom.split('/')
                                 dimmable = '%' in units
+                                if 'prec' in nprop[0].attributes:
+                                    prec = nprop[0].attributes['prec'].value
                                 nval = int(nval.replace(' ', '0'))
                             self.insert(nid, nname, nparent,
-                                        Node(self, nid, nval, nname, dimmable),
+                                        Node(self, nid, nval, nname, dimmable,
+                                             uom=units, prec=prec),
                                         ntype)
                         elif ntype == 'group':
                             mems = feature.getElementsByTagName('link')

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -206,7 +206,8 @@ class Nodes(object):
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value
-                                uom = nprop[0].attributes['uom'].value
+                                if 'uom' in nprop[0].attributes:
+                                    uom = nprop[0].attributes['uom'].value
                                 if uom in UNIT_OF_MEASURE:
                                     units = UNIT_OF_MEASURE[unit]
                                 else:

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -5,6 +5,7 @@ from time import sleep
 from xml.dom import minidom
 
 UNIT_OF_MEASURE = {
+    '97': 'stopped/closed/closing/open/opening',
     '73': 'watt',
     '11': 'unlocked/locked'
 }

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -226,11 +226,14 @@ class Nodes(object):
                     dimmable = '%' in state_uom
 
                     if nid in self.nids:
-                        node = self.getByID(id)
-                        node.aux_properties = aux_props
+                        node = self.getByID(nid)
                         node.uom = state_uom
                         node.prec = state_prec
                         node.dimmable = dimmable
+
+                        node.aux_properties = {}
+                        for prop in aux_props:
+                            node.aux_properties[prop.get(ATTR_ID)] = prop
 
                         node.status.update(state_val, silent=True)
                     else:

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -203,6 +203,8 @@ class Nodes(object):
                             nval = None
                             dimmable = False
                             nprop = feature.getElementsByTagName('property')
+                            uom = None
+                            prec = 0
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -179,25 +179,43 @@ class Nodes(object):
                         if ntype == 'folder':
                             self.insert(nid, nname, nparent, None, ntype)
                         elif ntype == 'node':
-                            nval = None
-                            dimmable = False
                             nprop = feature.getElementsByTagName('property')
-                            uom = None
-                            prec = 0
                             # Not all devices have properties
-                            if len(nprop) > 0:
-                                nval = nprop[0].attributes['value'].value
-                                if 'uom' in nprop[0].attributes:
-                                    uom = nprop[0].attributes['uom'].value
-                                units = uom.split('/')
-                                dimmable = '%' in units
-                                if 'prec' in nprop[0].attributes:
-                                    prec = nprop[0].attributes['prec'].value
-                                nval = int(nval.replace(' ', '0'))
-                            self.insert(nid, nname, nparent,
-                                        Node(self, nid, nval, nname, dimmable,
-                                             uom=units, prec=prec),
-                                        ntype)
+
+                            if len(nprop) == 0:
+                                self.insert(nid, nname, nparent,
+                                            Node(self, nid, None, nname,
+                                                 False),
+                                            ntype)
+                            else:
+                                for prop in nprop:
+                                    uom = ''
+                                    prec = '0'
+                                    prop_type = prop.attributes['id'].value
+                                    if 'uom' in prop.attributes:
+                                        uom = prop.attributes['uom'].value
+                                    units = uom.split('/')
+                                    dimmable = '%' in units
+                                    if 'prec' in prop.attributes:
+                                        prec = prop.attributes['prec'].value
+                                    nval = prop.attributes['value'].value
+                                    nval = int(nval.replace(' ', '0'))
+
+                                    if prop_type == 'ST':
+                                        self.insert(nid, nname, nparent,
+                                                    Node(self, nid, nval,
+                                                         nname, dimmable,
+                                                         uom=units, prec=prec),
+                                                    ntype)
+                                    else: # Ancilliary property
+                                        id = '{}_{}'.format(nid, prop_type)
+                                        pname = '{}_{}'.format(nname,
+                                                               prop_type)
+                                        self.insert(id, pname, nparent,
+                                                    Node(self, id, nval,
+                                                         pname, dimmable,
+                                                         uom=units, prec=prec),
+                                                    ntype)
                         elif ntype == 'group':
                             mems = feature.getElementsByTagName('link')
                             members = [mem.firstChild.nodeValue for mem in mems]

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -209,7 +209,7 @@ class Nodes(object):
                                 if 'uom' in nprop[0].attributes:
                                     uom = nprop[0].attributes['uom'].value
                                 if uom in UNIT_OF_MEASURE:
-                                    units = UNIT_OF_MEASURE[unit]
+                                    units = UNIT_OF_MEASURE[uom]
                                 else:
                                     units = uom.split('/')
                                 dimmable = '%' in units

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -12,6 +12,10 @@ UNIT_OF_MEASURE = {
         'open',
         'opening'
     ],
+    '78': [  # Motion, etc.
+        'on',
+        'off'
+    ],
     '73': [  # Energy Meter
         'watt'
     ],

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -4,6 +4,11 @@ from .node import Node
 from time import sleep
 from xml.dom import minidom
 
+UNIT_OF_MEASURE = {
+    '73': 'watt',
+    '11': 'unlocked/locked'
+}
+
 
 class Nodes(object):
 
@@ -185,8 +190,12 @@ class Nodes(object):
                             # Not all devices have properties
                             if len(nprop) > 0:
                                 nval = nprop[0].attributes['value'].value
-                                dimmable = '%' in \
-                                    nprop[0].attributes['uom'].value
+                                uom = nprop[0].attributes['uom'].value
+                                if uom in UNIT_OF_MEASURE:
+                                    units = UNIT_OF_MEASURE[unit]
+                                else:
+                                    units = uom.split('/')
+                                dimmable = '%' in units
                                 nval = int(nval.replace(' ', '0'))
                             self.insert(nid, nname, nparent,
                                         Node(self, nid, nval, nname, dimmable),

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -159,6 +159,32 @@ class Node(object):
             self.update(_change2update_interval)
             return True
 
+    def lock(self):
+        """ Sends a command via secure mode to z-wave locks."""
+        response = self.parent.parent.conn.nodeSecMd(self._id, '1')
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
+    def unlock(self):
+        """ Sends a command via secure mode to z-wave locks."""
+        response = self.parent.parent.conn.nodeSecMd(self._id, '0')
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
     def _get_notes(self):
         # Get the device notes, currently only the Spoken property is saved.
         notes_xml = self.parent.parent.conn.getNodeNotes(self._id)

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -70,7 +70,7 @@ def parse_xml_properties(xmldoc):
                 prec = attrs[ATTR_PREC].value
             except KeyError:
                 prec = '0'
-            units = uom.split('/')
+            units = uom if uom == 'n/a' else uom.split('/')
             val = int(val.replace(' ', '0'))
 
             if prop_id == STATE_PROPERTY:

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -54,21 +54,17 @@ def parse_xml_properties(xmldoc):
     if len(props) > 0:
         for prop in props:
             attrs = prop.attributes
-            try:
+            if ATTR_ID in prop.attributes.keys():
                 prop_id = attrs[ATTR_ID].value
-            except KeyError:
-                prop_id = None
-            try:
+            if ATTR_UOM in prop.attributes.keys():
                 uom = attrs[ATTR_UOM].value
-            except KeyError:
+            else:
                 uom = ''
-            try:
+            if ATTR_VALUE in prop.attributes.keys():
                 val = attrs[ATTR_VALUE].value
-            except KeyError:
-                val = None
-            try:
+            if ATTR_PREC in prop.attributes.keys():
                 prec = attrs[ATTR_PREC].value
-            except KeyError:
+            else:
                 prec = '0'
             units = uom if uom == 'n/a' else uom.split('/')
             val = int(val.replace(' ', '0'))

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -11,6 +11,30 @@ ATTR_UOM = 'uom'
 ATTR_VALUE = 'value'
 ATTR_PREC = 'prec'
 
+FAN_MODE_OFF = 'off'
+FAN_MODE_ON = 'on'
+FAN_MODE_AUTO = 'auto'
+
+CLIMATE_MODE_OFF = 'off'
+CLIMATE_MODE_HEAT = 'heat'
+CLIMATE_MODE_COOL = 'cool'
+CLIMATE_MODE_AUTO = 'auto'
+CLIMATE_MODE_FAN = 'fan'
+
+FAN_MODES = {
+    FAN_MODE_OFF: 0,
+    FAN_MODE_ON: 7,
+    FAN_MODE_AUTO: 8,
+}
+
+CLIMATE_MODES = {
+    CLIMATE_MODE_OFF: 0,
+    CLIMATE_MODE_HEAT: 1,
+    CLIMATE_MODE_COOL: 2,
+    CLIMATE_MODE_AUTO: 3,
+    CLIMATE_MODE_FAN: 4,
+}
+
 
 def parse_xml_properties(xmldoc):
     """
@@ -217,6 +241,111 @@ class Node(object):
             return False
         else:
             self.parent.parent.log.info('ISY dimmed node: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
+    def _fan_mode(self, mode):
+        """ Sends a command to the climate device to set the fan mode. """
+        if not hasattr(FAN_MODES, mode):
+            self.parent.parent.log.warning('Invalid fan mode: ' + mode)
+            return False
+
+        response = self.parent.parent.conn.nodeCliFS(FAN_MODES[mode])
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
+    def fan_auto(self):
+        """ Sends a command to the climate device to set fan mode=auto. """
+        return self._fan_mode(FAN_MODE_AUTO)
+
+    def fan_on(self):
+        """ Sends a command to the climate device to set fan mode=on. """
+        return self._fan_mode(FAN_MODE_ON)
+
+    def fan_off(self):
+        """ Sends a command to the climate device to set fan mode=off.  """
+        return self._fan_mode(FAN_MODE_OFF)
+
+    def _climate_mode(self, mode):
+        """ Sends a command to the climate device to set the system mode. """
+        if not hasattr(CLIMATE_MODES, mode):
+            self.parent.parent.log.warning('Invalid climate mode: ' + mode)
+            return False
+
+        response = self.parent.parent.nodeCliMD(CLIMATE_MODES[mode])
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
+    def climate_off(self):
+        """ Sends a command to the device to set the system mode=off. """
+        return self._climate_mode(CLIMATE_MODE_OFF)
+
+    def climate_auto(self):
+        """ Sends a command to the device to set the system mode=auto. """
+        return self._climate_mode(CLIMATE_MODE_AUTO)
+
+    def climate_heat(self):
+        """ Sends a command to the device to set the system mode=heat. """
+        return self._climate_mode(CLIMATE_MODE_HEAT)
+
+    def climate_cool(self):
+        """ Sends a command to the device to set the system mode=cool. """
+        return self._climate_mode(CLIMATE_MODE_COOL)
+
+    def climate_setpoint(self, val):
+        """ Sends a command to the device to set the system setpoints. """
+        # For some reason, wants 2 times the temperature
+        for cmd in ['nodeCliSPH', 'nodeCliSPC']:
+            response = getattr(self.parent.parent, cmd)(2 * val)
+
+            if response is None:
+                self.parent.parent.log.warning('ISY could not send command: ' +
+                                               self._id)
+                return False
+
+        self.parent.parent.log.info('ISY command sent: ' + self._id)
+        self.update(_change2update_interval)
+        return True
+
+    def climate_setpoint_heat(self, val):
+        """ Sends a command to the device to set the system heat setpoint. """
+        # For some reason, wants 2 times the temperature
+        response = self.parent.parent.nodeCliSPH(2 * val)
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
+            self.update(_change2update_interval)
+            return True
+
+    def climate_setpoint_cool(self, val):
+        """ Sends a command to the device to set the system cool setpoint. """
+        # For some reason, wants 2 times the temperature
+        response = self.parent.parent.nodeCliSPC(2 * val)
+
+        if response is None:
+            self.parent.parent.log.warning('ISY could not send command: ' +
+                                           self._id)
+            return False
+        else:
+            self.parent.parent.log.info('ISY command sent: ' + self._id)
             self.update(_change2update_interval)
             return True
 

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -28,11 +28,12 @@ def parse_xml_properties(xmldoc):
     if len(props) > 0:
         for prop in props:
             attrs = prop.attributes
-            prop_id = attrs[ATTR_ID] if ATTR_ID in attrs else None
+            prop_id = attrs[ATTR_ID].value if ATTR_ID in attrs else None
             uom = attrs[ATTR_UOM].value if ATTR_UOM in attrs else ''
             val = attrs[ATTR_VALUE].value if ATTR_VALUE in attrs else None
             prec = attrs[ATTR_PREC].value if ATTR_PREC in attrs else '0'
             units = uom.split('/')
+            val = int(val.replace(' ', '0'))
 
             if prop_id == STATE_PROPERTY:
                 state_val = val
@@ -105,6 +106,7 @@ class Node(object):
                     state_val, state_uom, state_prec, aux_props = parse_xml_properties(
                         xmldoc)
 
+                    self.aux_properties = {}
                     for prop in aux_props:
                         self.aux_properties[prop.get(ATTR_ID)] = prop
 

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -23,11 +23,13 @@ class Node(object):
     status = Property(0)
     hasChildren = False
 
-    def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False):
+    def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
+                 uom=None):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
         self.name = name
+        self.uom = uom
         self._spoken = spoken
 
         self.status = nval

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -24,12 +24,13 @@ class Node(object):
     hasChildren = False
 
     def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
-                 uom=None):
+                 uom=None, prec=0):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
         self.name = name
         self.uom = uom
+        self.prec = prec
         self._spoken = spoken
 
         self.status = nval

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -54,10 +54,22 @@ def parse_xml_properties(xmldoc):
     if len(props) > 0:
         for prop in props:
             attrs = prop.attributes
-            prop_id = attrs[ATTR_ID].value if ATTR_ID in attrs else None
-            uom = attrs[ATTR_UOM].value if ATTR_UOM in attrs else ''
-            val = attrs[ATTR_VALUE].value if ATTR_VALUE in attrs else None
-            prec = attrs[ATTR_PREC].value if ATTR_PREC in attrs else '0'
+            try:
+                prop_id = attrs[ATTR_ID].value
+            except KeyError:
+                prop_id = None
+            try:
+                uom = attrs[ATTR_UOM].value
+            except KeyError:
+                uom = ''
+            try:
+                val = attrs[ATTR_VALUE].value
+            except KeyError:
+                val = None
+            try:
+                prec = attrs[ATTR_PREC].value
+            except KeyError:
+                prec = '0'
             units = uom.split('/')
             val = int(val.replace(' ', '0'))
 

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -5,6 +5,7 @@ from xml.dom import minidom
 
 
 STATE_PROPERTY = 'ST'
+BATLVL_PROPERTY = 'BATLVL'
 ATTR_ID = 'id'
 ATTR_UOM = 'uom'
 ATTR_VALUE = 'value'
@@ -23,6 +24,7 @@ def parse_xml_properties(xmldoc):
     state_uom = []
     state_prec = ''
     aux_props = []
+    state_set = False
 
     props = xmldoc.getElementsByTagName('property')
     if len(props) > 0:
@@ -36,6 +38,11 @@ def parse_xml_properties(xmldoc):
             val = int(val.replace(' ', '0'))
 
             if prop_id == STATE_PROPERTY:
+                state_val = val
+                state_uom = units
+                state_prec = prec
+                state_set = True
+            elif prop_id == BATLVL_PROPERTY and not state_set:
                 state_val = val
                 state_uom = units
                 state_prec = prec

--- a/PyISY/Programs/folder.py
+++ b/PyISY/Programs/folder.py
@@ -85,6 +85,7 @@ class Folder(object):
         else:
             self.parent.parent.log.info('ISY ran else in program: ' + self._id)
             self.update(_change2update_interval)
+            return True
 
     def stop(self):
         """ Stops the object if it is running. """


### PR DESCRIPTION
For now, I'm sort of hacking your library to get locks to work in HASS..

``` python
    def lock(self, **kwargs) -> None:
        """Lock the device."""
        # Hack until PyISY is updated
        req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                         'SECMD', '1'])
        response = self._conn.request(req_url)

        if response is None:
            _LOGGER.error('Unable to lock device')

        self._node.update(0.5)

    def unlock(self, **kwargs) -> None:
        """Unlock the device."""
        # Hack until PyISY is updated
        req_url = self._conn.compileURL(['nodes', self.unique_id, 'cmd',
                                         'SECMD', '0'])
        response = self._conn.request(req_url)

        if response is None:
            _LOGGER.error('Unable to lock device')

        self._node.update(0.5)
```

Also added support for aux. properties (battery level, humidity, set points, etc.) and now the commands for climate (thermostats)!