### PR TITLE
Zwave multisensor support

### DIFF
--- a/PyISY/Connection.py
+++ b/PyISY/Connection.py
@@ -165,6 +165,11 @@ class Connection(object):
         result = self.request(req_url)
         return result
 
+    def getNode(self, nid):
+        req_url = self.compileURL(['nodes', nid])
+        response = self.request(req_url)
+        return response
+
     def updateNode(self, nid):
         req_url = self.compileURL(['nodes', nid, 'get', 'ST'])
         response = self.request(req_url)

--- a/PyISY/ISY.py
+++ b/PyISY/ISY.py
@@ -1,5 +1,6 @@
 from .Connection import Connection
 from .configuration import configuration
+from .device_specs import device_specs
 from .Nodes import Nodes
 from .Programs import Programs
 from .Events import get_stream
@@ -79,8 +80,12 @@ class ISY(object):
 
         else:
             self._connected = True
+
+            config = self.conn.getConfiguration()
             self.configuration = configuration(self,
-                                               xml=self.conn.getConfiguration())
+                                               xml=config)
+            self.device_specs = device_specs(self, xml=config)
+
             self.nodes = Nodes(self, xml=self.conn.getNodes())
             self.programs = Programs(self, xml=self.conn.getPrograms())
             self.variables = Variables(self, xml=self.conn.getVariables())

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -113,7 +113,8 @@ class Node(object):
     hasChildren = False
 
     def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
-                 notes=False, uom=None, prec=0, aux_properties=None):
+                 notes=False, uom=None, prec=0, aux_properties=None,
+                 dev_type=None, ntype=None):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
@@ -122,6 +123,8 @@ class Node(object):
         self.uom = uom
         self.prec = prec
         self._spoken = spoken
+        self.dev_type = dev_type
+        self.ntype = ntype
 
         self.aux_properties = aux_properties or {}
         if isinstance(self.aux_properties, list):

--- a/PyISY/device_specs.py
+++ b/PyISY/device_specs.py
@@ -1,0 +1,35 @@
+from xml.dom import minidom
+
+
+class device_specs(dict):
+
+    def __init__(self, parent, xml=None):
+        """
+        Initiates configuration class.
+
+        parent: ISY class
+        xml: String of xml data containing the configuration data
+        """
+        super(device_specs, self).__init__()
+        self.parent = parent
+
+        if xml is not None:
+            self.parse(xml)
+
+    def parse(self, xml):
+        """
+        Parses the xml data.
+
+        xml: String of the xml data
+        """
+        xmldoc = minidom.parseString(xml)
+        specs = xmldoc.getElementsByTagName('deviceSpecs')[0] # type: minidom.Element
+
+        for spec in specs.childNodes: # type: minidom.Element
+            if spec.nodeType == minidom.Element.ELEMENT_NODE:
+                name = spec.tagName
+                value = spec.childNodes[0].data
+                self[name] = value
+
+        self.parent.log.info('ISY Loaded Device Specs')
+

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 
 setup(
     name='PyISY',
-    version='1.0.8',
+    version='1.0.9',
     license='Apache License 2.0',
     url='http://automic.us/projects/pyisy',
-    download_url='https://github.com/automicus/pyisy/tarball/1.0.8',
+    download_url='https://github.com/automicus/pyisy/tarball/1.0.9',
     author='Ryan Kraus',
     author_email='automicus@gmail.com',
     description='Python module to talk to ISY994 from UDI.',


### PR DESCRIPTION
I have hacked in support for multisensor-type ZWave devices (such as the Aeotec Multisensor Gen6, model ZW100). These devices report a bunch of different sensors as properties. Here's an example from 5.0.10 firmware:

```
<?xml version="1.0" encoding="UTF-8"?>
<nodeInfo>
    <node flag="128" nodeDefId="UZW0028">
        <address>ZW003_1</address>
        <name>Office Sensor</name>
        <family>4</family>
        <type>4.33.1.0</type>
        <enabled>true</enabled>
        <deviceClass>0</deviceClass>
        <wattage>0</wattage>
        <dcPeriod>0</dcPeriod>
        <startDelay>0</startDelay>
        <endDelay>0</endDelay>
        <pnode>ZW003_1</pnode>
        <sgid>1</sgid>
        <devtype>
            <gen>4.33.1</gen>
            <mfg>134.258.100</mfg>
            <cat>118</cat>
        </devtype>
        <ELK_ID>C07</ELK_ID>
    </node>
    <properties>
        <property id="BATLVL" value="100" formatted="100%" uom="51" />
        <property id="CLIHUM" value="58" formatted="58%" uom="22" />
        <property id="CLITEMP" value="717" formatted="71.7°F" uom="17" prec="1" />
        <property id="LUMIN" value="36" formatted="36 lux" uom="36" />
        <property id="UV" value="0" formatted="0 UV Index" uom="71" />
    </properties>
</nodeInfo>
```

NOTE: For some reason, the ISY doesn't report these properties when you do `GET /nodes`. You have to call `GET /nodes/<node_id>` individually for each device. Maybe this will be fixed in a future version of the ISY firmware.

This patch works for any Insteon or ZWave device that reports properties besides ST. (For example, Insteon switches report OL and RR). Here's how it works:

1. Extra properties are created as nodes with a new node type 'property'. The name of the new node is the parent device name followed by the property name. For the example above, the following nodes would be created:
   * ZW003_1
   * ZW003_1_BATLVL
   * ZW003_1_CLIHUM
   * ZW003_1_CLITEMP
   * ZW003_1_LUMIN
   * ZW003_1_UV

2. Changes to `Nodes.parse()` to create the property nodes.

3. Changes to `Nodes._upmsg()` and `Nodes.update()` to pass ISY updates to the correct property nodes.

4. Addition of a `getNode()` method in the `Connection` object so PyISY can retrieve individual device details as per my NOTE above.

I am testing this code with Home Assistant after making modifications there too. Let me know what you think! Thanks.