### PR TITLE
Pass control events to nodes for emitting to subscribers

### DIFF
--- a/PyISY/Events/events.py
+++ b/PyISY/Events/events.py
@@ -63,6 +63,10 @@ class EventStream(socket.socket):
         # direct the event message
         try:
             cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
+        except IndexError:
+            # No control tag
+            pass
+        else:
             if cntrl == '_0':  # ISY HEARTBEAT
                 self._lasthb = datetime.datetime.now()
                 self._hbwait = int(xmldoc.getElementsByTagName('action')[0].
@@ -80,8 +84,6 @@ class EventStream(socket.socket):
                     self.parent.variables._upmsg(xmldoc)
                 elif '<id>' in msg:  # PROGRAM
                     self.parent.programs._upmsg(xmldoc)
-        except:
-            pass
 
         # A wild stream id appears!
         if 'sid=' in msg and 'sid' not in self.data:

--- a/PyISY/Events/eventsSSL.py
+++ b/PyISY/Events/eventsSSL.py
@@ -77,6 +77,10 @@ class SSLEventStream(object):
         # direct the event message
         try:
             cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
+        except IndexError:
+            # No control tag
+            pass
+        else:
             if cntrl == '_0':  # ISY HEARTBEAT
                 self._lasthb = datetime.datetime.now()
                 self._hbwait = int(xmldoc.getElementsByTagName('action')[0].
@@ -97,8 +101,6 @@ class SSLEventStream(object):
                 else:  # SOMETHING HAPPENED WITH A PROGRAM FOLDER
                     # but they ISY didn't tell us what, so...
                     self.parent.programs.update()
-        except:
-            pass
 
         # A wild stream id appears!
         if 'sid=' in msg and 'sid' not in self.data:

--- a/PyISY/Events/eventsSSL.py
+++ b/PyISY/Events/eventsSSL.py
@@ -11,6 +11,18 @@ from PyISY.Events import strings
 
 POLL_TIME = 5
 
+control_events = [
+    'DON',
+    'DOF',
+    'DFON',
+    'DFOF',
+    'BRT',
+    'DIM',
+    'FDDOWN',
+    'FDUP',
+    'FDSTOP'
+]
+
 
 class SSLEventStream(object):
 
@@ -77,6 +89,9 @@ class SSLEventStream(object):
 
         # direct the event message
         cntrl = '<control>{0}</control>'
+        wrapped_control_events = [
+            cntrl.format(e) for e in control_events]
+
         if cntrl.format('_0') in msg:  # ISY HEARTBEAT
             self._lasthb = datetime.datetime.now()
             self._hbwait = int(xmldoc.getElementsByTagName('action')[0].
@@ -84,6 +99,8 @@ class SSLEventStream(object):
             self.parent.log.debug('ISY HEARTBEAT: ' + self._lasthb.isoformat())
         if cntrl.format('ST') in msg:  # NODE UPDATE
             self.parent.nodes._upmsg(xmldoc)
+        if any(cmd in msg for cmd in wrapped_control_events):
+            self.parent.nodes._controlmsg(xmldoc)
         elif cntrl.format('_11') in msg:  # WEATHER UPDATE
             if self.parent.configuration['Weather Information']:
                 self.parent.climate._upmsg(xmldoc)

--- a/PyISY/Events/eventsSSL.py
+++ b/PyISY/Events/eventsSSL.py
@@ -11,19 +11,6 @@ from PyISY.Events import strings
 
 POLL_TIME = 5
 
-control_events = [
-    'DON',
-    'DOF',
-    'DFON',
-    'DFOF',
-    'BRT',
-    'DIM',
-    'FDDOWN',
-    'FDUP',
-    'FDSTOP'
-]
-
-
 class SSLEventStream(object):
 
     def __init__(self, parent, lost_fun=None):
@@ -88,30 +75,30 @@ class SSLEventStream(object):
         self.parent.log.debug('ISY Update Received:\n' + msg)
 
         # direct the event message
-        cntrl = '<control>{0}</control>'
-        wrapped_control_events = [
-            cntrl.format(e) for e in control_events]
-
-        if cntrl.format('_0') in msg:  # ISY HEARTBEAT
-            self._lasthb = datetime.datetime.now()
-            self._hbwait = int(xmldoc.getElementsByTagName('action')[0].
-                               firstChild.toxml())
-            self.parent.log.debug('ISY HEARTBEAT: ' + self._lasthb.isoformat())
-        if cntrl.format('ST') in msg:  # NODE UPDATE
-            self.parent.nodes._upmsg(xmldoc)
-        if any(cmd in msg for cmd in wrapped_control_events):
-            self.parent.nodes._controlmsg(xmldoc)
-        elif cntrl.format('_11') in msg:  # WEATHER UPDATE
-            if self.parent.configuration['Weather Information']:
-                self.parent.climate._upmsg(xmldoc)
-        elif cntrl.format('_1') in msg:  # VARIABLE OR PROGRAM UPDATE
-            if '<var' in msg:  # VARIABLE
-                self.parent.variables._upmsg(xmldoc)
-            elif '<id>' in msg:  # PROGRAM
-                self.parent.programs._upmsg(xmldoc)
-            else:  # SOMETHING HAPPENED WITH A PROGRAM FOLDER
-                # but they ISY didn't tell us what, so...
-                self.parent.programs.update()
+        try:
+            cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
+            if cntrl == '_0':  # ISY HEARTBEAT
+                self._lasthb = datetime.datetime.now()
+                self._hbwait = int(xmldoc.getElementsByTagName('action')[0].
+                                   firstChild.toxml())
+                self.parent.log.debug('ISY HEARTBEAT: ' + self._lasthb.isoformat())
+            if cntrl == 'ST':  # NODE UPDATE
+                self.parent.nodes._upmsg(xmldoc)
+            if  cntrl[0] != '_': # NODE CONTROL EVENT
+                self.parent.nodes._controlmsg(xmldoc)
+            elif cntrl == '_11':  # WEATHER UPDATE
+                if self.parent.configuration['Weather Information']:
+                    self.parent.climate._upmsg(xmldoc)
+            elif cntrl == '_1':  # VARIABLE OR PROGRAM UPDATE
+                if '<var' in msg:  # VARIABLE
+                    self.parent.variables._upmsg(xmldoc)
+                elif '<id>' in msg:  # PROGRAM
+                    self.parent.programs._upmsg(xmldoc)
+                else:  # SOMETHING HAPPENED WITH A PROGRAM FOLDER
+                    # but they ISY didn't tell us what, so...
+                    self.parent.programs.update()
+        except:
+            pass
 
         # A wild stream id appears!
         if 'sid=' in msg and 'sid' not in self.data:

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -144,10 +144,16 @@ class Nodes(object):
     def _controlmsg(self, xmldoc):
         """Passes Control events from an event stream message to nodes, for
         sending out to subscribers."""
-        nid = xmldoc.getElementsByTagName('node')[0].firstChild.toxml()
-        cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
-        self.getByID(nid).controlEvents.notify(cntrl)
-        self.parent.log.info('ISY Node Control Event: ' + nid + ' ' + cntrl)
+        try:
+            nid = xmldoc.getElementsByTagName('node')[0].firstChild.toxml()
+            cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
+            self.getByID(nid).controlEvents.notify(cntrl)
+            self.parent.log.info('ISY Node Control Event: ' + nid + ' ' + cntrl)
+        except:
+            # Control event did not have a node associated,
+            # so we're skipping it
+            pass
+
 
     def parse(self, xml):
         """

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -141,6 +141,14 @@ class Nodes(object):
         self.getByID(nid).status.update(nval, force=True, silent=True)
         self.parent.log.info('ISY Updated Node: ' + nid)
 
+    def _controlmsg(self, xmldoc):
+        """Passes Control events from an event stream message to nodes, for
+        sending out to subscribers."""
+        nid = xmldoc.getElementsByTagName('node')[0].firstChild.toxml()
+        cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
+        self.getByID(nid).controlEvents.notify(cntrl)
+        self.parent.log.info('ISY Node Control Event: ' + nid + ' ' + cntrl)
+
     def parse(self, xml):
         """
         Parses the xml data.

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -173,12 +173,6 @@ class Nodes(object):
                 features = xmldoc.getElementsByTagName(ntype)
 
                 for feature in features:
-                    family_tag = feature.getElementsByTagName('family')
-                    if len(family_tag) > 0:
-                        family = family_tag[0].firstChild.toxml()
-                    else:
-                        family = None
-
                     nid = feature.getElementsByTagName('address')[0] \
                         .firstChild.toxml()
                     nname = feature.getElementsByTagName('name')[0] \
@@ -186,13 +180,8 @@ class Nodes(object):
                     try:
                         nparent = feature.getElementsByTagName('parent')[0] \
                             .firstChild.toxml()
-                        nname = feature.getElementsByTagName('name')[0] \
-                            .firstChild.toxml()
-                        try:
-                            nparent = feature.getElementsByTagName('parent')[0] \
-                                .firstChild.toxml()
-                        except IndexError:
-                            nparent = None
+                    except IndexError:
+                        nparent = None
 
                     if ntype == 'folder':
                         self.insert(nid, nname, nparent, None, ntype)

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -147,12 +147,12 @@ class Nodes(object):
         try:
             nid = xmldoc.getElementsByTagName('node')[0].firstChild.toxml()
             cntrl = xmldoc.getElementsByTagName('control')[0].firstChild.toxml()
-            self.getByID(nid).controlEvents.notify(cntrl)
-            self.parent.log.info('ISY Node Control Event: ' + nid + ' ' + cntrl)
-        except:
-            # Control event did not have a node associated,
-            # so we're skipping it
-            pass
+        except IndexError:
+            # If there is no node associated with the control message we ignore it
+            return
+
+        self.getByID(nid).controlEvents.notify(cntrl)
+        self.parent.log.info('ISY Node Control Event: ' + nid + ' ' + cntrl)
 
 
     def parse(self, xml):
@@ -187,7 +187,7 @@ class Nodes(object):
                         try:
                             nparent = feature.getElementsByTagName('parent')[0] \
                                 .firstChild.toxml()
-                        except:
+                        except IndexError:
                             nparent = None
 
                         if ntype == 'folder':

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -93,6 +93,32 @@ def parse_xml_properties(xmldoc):
     return state_val, state_uom, state_prec, aux_props
 
 
+class EventEmitter(object):
+    def __init__(self):
+        self._subscribers = []
+
+    def subscribe(self, callback):
+        listener = EventListener(self, callback)
+        self._subscribers.append(listener)
+        return listener
+
+    def unsubscribe(self, listener):
+        self._subscribers.remove(listener)
+
+    def notify(self, event):
+        for subscriber in self._subscribers:
+            subscriber.callback(event)
+
+
+class EventListener(object):
+    def __init__(self, emitter, callback):
+        self._emitter = emitter
+        self.callback = callback
+
+    def unsubscribe(self):
+        self._emitter.unsubscribe(self)
+
+
 class Node(object):
     """
     This class handles ISY nodes.
@@ -127,6 +153,8 @@ class Node(object):
 
         self.status = nval
         self.status.reporter = self.__report_status__
+
+        self.controlEvents = EventEmitter()
 
     def __str__(self):
         """ Returns a string representation of the node. """


### PR DESCRIPTION
This adds quick and dirty support for emitting "control" events from the ISY event stream out to subscribers via the nodes associated with the control events.

The primary use case I am trying to solve with this is allowing Home Assistant to be aware of button presses on switches, not just when a light state changes. This will allow creating special automations for when buttons are double-pressed, or even using an Insteon controller (such as the 8-button remote) without it needing to be linked to any actual devices in the Insteon network.

It will ALSO open the door to properly handling heartbeats, which are always "on" events. Since they never emit an "off", the events never make it out to Home Assistant.

Implements #33