### PR TITLE
Remove family filter that was blocking all scenes from getting nodes

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -165,49 +165,49 @@ class Nodes(object):
                     else:
                         family = None
 
-                    if family is not '6':  # ignore controller group
-                        nid = feature.getElementsByTagName('address')[0] \
+                    nid = feature.getElementsByTagName('address')[0] \
+                        .firstChild.toxml()
+                    nname = feature.getElementsByTagName('name')[0] \
+                        .firstChild.toxml()
+                    try:
+                        nparent = feature.getElementsByTagName('parent')[0] \
                             .firstChild.toxml()
-                        nname = feature.getElementsByTagName('name')[0] \
-                            .firstChild.toxml()
-                        try:
-                            nparent = feature.getElementsByTagName('parent')[0] \
-                                .firstChild.toxml()
-                        except:
-                            nparent = None
+                    except:
+                        nparent = None
 
-                        if ntype == 'folder':
-                            self.insert(nid, nname, nparent, None, ntype)
-                        elif ntype == 'node':
-                            (state_val, state_uom, state_prec,
-                             aux_props) = parse_xml_properties(feature)
+                    if ntype == 'folder':
+                        self.insert(nid, nname, nparent, None, ntype)
+                    elif ntype == 'node':
+                        (state_val, state_uom, state_prec,
+                         aux_props) = parse_xml_properties(feature)
 
-                            dimmable = '%' in state_uom
+                        dimmable = '%' in state_uom
 
+                        self.insert(nid, nname, nparent,
+                                    Node(self, nid, state_val, nname,
+                                         dimmable,
+                                         uom=state_uom, prec=state_prec,
+                                         aux_properties=aux_props),
+                                    ntype)
+                    elif ntype == 'group':
+                        flag = feature.attributes['flag'].value
+                        # Ignore groups that contain 0x08 in the flag since that is a ISY scene that
+                        # contains every device/scene so it will contain some scenes we have not
+                        # seen yet so they are not defined and it includes the ISY MAC addrees in
+                        # newer versions of ISY 5.0.6+ ..
+                        if int(flag) & 0x08:
+                            self.parent.log.info('Skipping group flag=' + flag + " " + nid )
+                        else:
+                            mems = feature.getElementsByTagName('link')
+                            # Build list of members
+                            members = [mem.firstChild.nodeValue for mem in mems]
+                            # Build list of controllers
+                            controllers = []
+                            for mem in mems:
+                                if int(mem.attributes['type'].value) == 16:
+                                    controllers.append(mem.firstChild.nodeValue)
                             self.insert(nid, nname, nparent,
-                                        Node(self, nid, state_val, nname,
-                                             dimmable,
-                                             uom=state_uom, prec=state_prec,
-                                             aux_properties=aux_props),
-                                        ntype)
-                        elif ntype == 'group':
-                            flag = feature.attributes['flag'].value
-                            # Ignore group flag=12 since that is a ISY scene that contains every device/scene
-                            # so it will contain some scenes we have not seen yet so they are not defined
-                            # and it includes the ISY MAC addrees in newer versions of ISY 5.0.6+ ..
-                            if int(flag) == 12:
-                                self.parent.log.info('Skipping group flag=' + flag + " " + nid )
-                            else:
-                                mems = feature.getElementsByTagName('link')
-                                # Build list of members
-                                members = [mem.firstChild.nodeValue for mem in mems]
-                                # Build list of controllers
-                                controllers = []
-                                for mem in mems:
-                                    if int(mem.attributes['type'].value) == 16:
-                                        controllers.append(mem.firstChild.nodeValue)
-                                self.insert(nid, nname, nparent,
-                                            Group(self, nid, nname, members, controllers), ntype)
+                                        Group(self, nid, nname, members, controllers), ntype)
 
             self.parent.log.info('ISY Loaded Nodes')
 


### PR DESCRIPTION
Removing the filter based on family as per the discussion in #27

I've tested this using Home Assistant, which will now successfully import the groups/scenes.

I also slightly changed the logic for how the root node is detected, using a bitmask check rather than checking for an exact integer value, which will be more accurate in the event that the root node gets a new flag added to it.