### PR TITLE
Expose more params

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -182,8 +182,14 @@ class Nodes(object):
                         parent_nid = None
 
                     try:
-                        nodeDefId = feature.attributes['nodeDefId'].value
+                        type = feature.getElementsByTagName('type')[0] \
+                            .firstChild.toxml()
                     except:
+                        type = None
+
+                    try:
+                        nodeDefId = feature.attributes['nodeDefId'].value
+                    except KeyError:
                         nodeDefId = None
 
                     if ntype == 'folder':
@@ -200,7 +206,8 @@ class Nodes(object):
                                          uom=state_uom, prec=state_prec,
                                          aux_properties=aux_props,
                                          node_def_id=nodeDefId,
-                                         parent_nid=parent_nid),
+                                         parent_nid=parent_nid,
+                                         type=type),
                                     ntype)
                     elif ntype == 'group':
                         flag = feature.attributes['flag'].value

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -175,6 +175,17 @@ class Nodes(object):
                     except:
                         nparent = None
 
+                    try:
+                        parent_nid = feature.getElementsByTagName('pnode')[0] \
+                            .firstChild.toxml()
+                    except:
+                        parent_nid = None
+
+                    try:
+                        nodeDefId = feature.attributes['nodeDefId'].value
+                    except:
+                        nodeDefId = None
+
                     if ntype == 'folder':
                         self.insert(nid, nname, nparent, None, ntype)
                     elif ntype == 'node':
@@ -187,7 +198,9 @@ class Nodes(object):
                                     Node(self, nid, state_val, nname,
                                          dimmable,
                                          uom=state_uom, prec=state_prec,
-                                         aux_properties=aux_props),
+                                         aux_properties=aux_props,
+                                         node_def_id=nodeDefId,
+                                         parent_nid=parent_nid),
                                     ntype)
                     elif ntype == 'group':
                         flag = feature.attributes['flag'].value

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -165,49 +165,49 @@ class Nodes(object):
                     else:
                         family = None
 
-                    if family is not '6':  # ignore controller group
-                        nid = feature.getElementsByTagName('address')[0] \
+                    nid = feature.getElementsByTagName('address')[0] \
+                        .firstChild.toxml()
+                    nname = feature.getElementsByTagName('name')[0] \
+                        .firstChild.toxml()
+                    try:
+                        nparent = feature.getElementsByTagName('parent')[0] \
                             .firstChild.toxml()
-                        nname = feature.getElementsByTagName('name')[0] \
-                            .firstChild.toxml()
-                        try:
-                            nparent = feature.getElementsByTagName('parent')[0] \
-                                .firstChild.toxml()
-                        except:
-                            nparent = None
+                    except:
+                        nparent = None
 
-                        if ntype == 'folder':
-                            self.insert(nid, nname, nparent, None, ntype)
-                        elif ntype == 'node':
-                            (state_val, state_uom, state_prec,
-                             aux_props) = parse_xml_properties(feature)
+                    if ntype == 'folder':
+                        self.insert(nid, nname, nparent, None, ntype)
+                    elif ntype == 'node':
+                        (state_val, state_uom, state_prec,
+                         aux_props) = parse_xml_properties(feature)
 
-                            dimmable = '%' in state_uom
+                        dimmable = '%' in state_uom
 
+                        self.insert(nid, nname, nparent,
+                                    Node(self, nid, state_val, nname,
+                                         dimmable,
+                                         uom=state_uom, prec=state_prec,
+                                         aux_properties=aux_props),
+                                    ntype)
+                    elif ntype == 'group':
+                        flag = feature.attributes['flag'].value
+                        # Ignore groups that contain 0x08 in the flag since that is a ISY scene that
+                        # contains every device/scene so it will contain some scenes we have not
+                        # seen yet so they are not defined and it includes the ISY MAC addrees in
+                        # newer versions of ISY 5.0.6+ ..
+                        if int(flag) & 0x08:
+                            self.parent.log.info('Skipping group flag=' + flag + " " + nid )
+                        else:
+                            mems = feature.getElementsByTagName('link')
+                            # Build list of members
+                            members = [mem.firstChild.nodeValue for mem in mems]
+                            # Build list of controllers
+                            controllers = []
+                            for mem in mems:
+                                if int(mem.attributes['type'].value) == 16:
+                                    controllers.append(mem.firstChild.nodeValue)
                             self.insert(nid, nname, nparent,
-                                        Node(self, nid, state_val, nname,
-                                             dimmable,
-                                             uom=state_uom, prec=state_prec,
-                                             aux_properties=aux_props),
-                                        ntype)
-                        elif ntype == 'group':
-                            flag = feature.attributes['flag'].value
-                            # Ignore group flag=12 since that is a ISY scene that contains every device/scene
-                            # so it will contain some scenes we have not seen yet so they are not defined
-                            # and it includes the ISY MAC addrees in newer versions of ISY 5.0.6+ ..
-                            if int(flag) == 12:
-                                self.parent.log.info('Skipping group flag=' + flag + " " + nid )
-                            else:
-                                mems = feature.getElementsByTagName('link')
-                                # Build list of members
-                                members = [mem.firstChild.nodeValue for mem in mems]
-                                # Build list of controllers
-                                controllers = []
-                                for mem in mems:
-                                    if int(mem.attributes['type'].value) == 16:
-                                        controllers.append(mem.firstChild.nodeValue)
-                                self.insert(nid, nname, nparent,
-                                            Group(self, nid, nname, members, controllers), ntype)
+                                        Group(self, nid, nname, members, controllers), ntype)
 
             self.parent.log.info('ISY Loaded Nodes')
 

--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -172,19 +172,19 @@ class Nodes(object):
                     try:
                         nparent = feature.getElementsByTagName('parent')[0] \
                             .firstChild.toxml()
-                    except:
+                    except IndexError:
                         nparent = None
 
                     try:
                         parent_nid = feature.getElementsByTagName('pnode')[0] \
                             .firstChild.toxml()
-                    except:
+                    except IndexError:
                         parent_nid = None
 
                     try:
                         type = feature.getElementsByTagName('type')[0] \
                             .firstChild.toxml()
-                    except:
+                    except IndexError:
                         type = None
 
                     try:

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -114,7 +114,8 @@ class Node(object):
     hasChildren = False
 
     def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
-                 notes=False, uom=None, prec=0, aux_properties=None):
+                 notes=False, uom=None, prec=0, aux_properties=None,
+                 node_def_id=None, parent_nid=None):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
@@ -124,6 +125,12 @@ class Node(object):
         self.prec = prec
         self._spoken = spoken
         self.aux_properties = aux_properties or {}
+        self.node_def_id = node_def_id
+
+        if(parent_nid != nid):
+            self.parent_nid = parent_nid
+        else:
+            self.parent_nid = None
 
         self.status = nval
         self.status.reporter = self.__report_status__
@@ -131,6 +138,10 @@ class Node(object):
     def __str__(self):
         """ Returns a string representation of the node. """
         return 'Node(' + self._id + ')'
+
+    @property
+    def nid(self):
+        return self._id
 
     def __report_status__(self, new_val):
         self.on(new_val)
@@ -409,6 +420,18 @@ class Node(object):
                     if self._id in self.parent.parent.nodes[child[2]].controllers:
                         groups.append(child[2])
         return groups
+
+    @property
+    def parent_node(self):
+        """
+        Returns the parent node object of this node. Typically this is for
+        devices that are represented as multiple nodes in the ISY, such as
+        door and leak sensors. Returns None if there is no parent.
+        """
+        try:
+            return self.parent.getByID(self.parent_nid)
+        except:
+            return None
 
     @property
     def spoken(self):

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -115,7 +115,7 @@ class Node(object):
 
     def __init__(self, parent, nid, nval, name, dimmable=True, spoken=False,
                  notes=False, uom=None, prec=0, aux_properties=None,
-                 node_def_id=None, parent_nid=None):
+                 node_def_id=None, parent_nid=None, type=None):
         self.parent = parent
         self._id = nid
         self.dimmable = dimmable
@@ -126,6 +126,7 @@ class Node(object):
         self._spoken = spoken
         self.aux_properties = aux_properties or {}
         self.node_def_id = node_def_id
+        self.type = type
 
         if(parent_nid != nid):
             self.parent_nid = parent_nid


### PR DESCRIPTION
**Note: this PR is branched off of PR #35, and should be merged after**

This simply adds a few more attributes to the Node object that come from the ISY's payload that I needed when improving the ISY994 support in Home Assistant:

* `nid` is the node id. It was only available in a protected property before. This was added mainly because of the parent_nid use-case below.
* `node_def_id` is the NodeDefId introduced in the 5.x builds of the ISY firmware. They make determining the broad type of device such as dimmer, relay, sensor very convenient.
* `parent_nid` is the parent node - this only applies when a single device uses multiple nodes (like sensors, keypads, and multi-button remotes). In addition to exposing the `parent_nid` string, there is also a `parent_node` property that will return the parent node itself.
* `type` is the type parameter from ISY, which represents the exact physical hardware that a node comes from. This is necessary to determine if a node is a motion sensor, leak sensor, etc.