### PR TITLE
Set node value to -1 when ISY reports it as unknown (blank string)

### DIFF
--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -68,10 +68,12 @@ def parse_xml_properties(xmldoc):
                 prec = '0'
             #print "prop=",prop.toprettyxml();
             units = uom if uom == 'n/a' else uom.split('/')
-            if (val == ""):
-                val = -1
+
+            val = val.strip()
+            if val == "":
+                val = -1 * float('inf')
             else:
-                val = int(val.replace(' ', '-1'))
+                val = int(val)
 
             if prop_id == STATE_PROPERTY:
                 state_val = val

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -69,9 +69,9 @@ def parse_xml_properties(xmldoc):
             #print "prop=",prop.toprettyxml();
             units = uom if uom == 'n/a' else uom.split('/')
             if (val == ""):
-                val = 0
+                val = -1
             else:
-                val = int(val.replace(' ', '0'))
+                val = int(val.replace(' ', '-1'))
 
             if prop_id == STATE_PROPERTY:
                 state_val = val


### PR DESCRIPTION
There is a very distinct difference between _blank_ values and 0 values as reported by the ISY.

Blank values are used when the ISY does not know the status of a node, such as in cases where a battery-powered sensor has not reported a state since the ISY last booted up. The current implementation would cause leak sensors, for example, to report as WET (the dry node would be 0).

This change makes the value be -1 to hopefully reduce the magnitude of breaking change that this could be, while still allowing consuming applications to treat UNKNOWN values as different than OFF. (I didn't want to go so far as to make the Value sometimes be a non-integer.) Still, I would recommend a minor version number update to indicate the potential breaking change.