### PR TITLE
Fix Node.aux_properties inconsistent typing

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -268,9 +268,7 @@ class Nodes(object):
                         node.prec = state_prec
                         node.dimmable = dimmable
 
-                        node.aux_properties = {}
-                        for prop in aux_props:
-                            node.aux_properties[prop.get(ATTR_ID)] = prop
+                        node.update_aux_properties(aux_props)
 
                         node.status.update(state_val, silent=True)
                     else:

--- a/PyISY/Nodes/node.py
+++ b/PyISY/Nodes/node.py
@@ -152,7 +152,8 @@ class Node(object):
         self.uom = uom
         self.prec = prec
         self._spoken = spoken
-        self.aux_properties = aux_properties or {}
+        self.aux_properties = {}
+        self.update_aux_properties(aux_properties)
         self.node_def_id = node_def_id
         self.type = type
 
@@ -169,6 +170,13 @@ class Node(object):
     def __str__(self):
         """ Returns a string representation of the node. """
         return 'Node(' + self._id + ')'
+
+    def update_aux_properties(self, aux_props):
+        self.aux_properties = {}
+
+        if aux_props is not None:
+            for prop in aux_props:
+                self.aux_properties[prop.get(ATTR_ID)] = prop
 
     @property
     def nid(self):
@@ -193,9 +201,7 @@ class Node(object):
                     state_val, state_uom, state_prec, aux_props = parse_xml_properties(
                         xmldoc)
 
-                    self.aux_properties = {}
-                    for prop in aux_props:
-                        self.aux_properties[prop.get(ATTR_ID)] = prop
+                    self.update_aux_properties(aux_props)
 
                     self.uom = state_uom
                     self.prec = state_prec


### PR DESCRIPTION
aux_properties is supposed to be a Dict. However, a couple places in the code would initialize a Node by passing in a List.

I fixed this by moving some duplicate List->Dict code in to a method that is called whenever the aux_properties need to be updated, which is also used on Node __init__.

Fixes https://github.com/home-assistant/home-assistant/issues/13160