### PR TITLE
Events Readline fix

### DIFF
--- a/PyISY/Events/events.py
+++ b/PyISY/Events/events.py
@@ -145,16 +145,15 @@ class EventStream(object):
     def connect(self):
         if not self._connected:
             try:
-                super(EventStream, self).connect((self.data['addr'],
-                                                self.data['port']))
+                self.socket.connect((self.data['addr'], self.data['port']))
             except OSError:
                 self.parent.log.error('PyISY could not connect to ISY ' +
                                       'event stream.')
                 if self._lostfun is not None:
                     self._lostfun()
                 return False
-            self.setblocking(0)
-            self._writer = self.makefile("w")
+            self.socket.setblocking(0)
+            self._writer = self.socket.makefile("w")
             self._connected = True
             return True
         else:
@@ -162,7 +161,7 @@ class EventStream(object):
 
     def disconnect(self):
         if self._connected:
-            self.close()
+            self.socket.close()
             self._connected = False
             self._subscribed = False
             self._running = False


### PR DESCRIPTION
@OverloadUT, @altersis -- just giving y'all an option for addressing #51.

I pulled this out of the changes I had already made to my fork in #44 which combines the ssl and non-ssl versions of the EventStream class.

This just takes what was already implemented in EventStreamSSL and carries it back to EventStream.  It does not include any additional checking of the the stream contents, leaving that for the `_routemsg` function to throw an exception if there was a bad xml string received.

