### PR TITLE
1.1.2 version bump and setup.py cleanup

### DIFF
--- a/PyISY/__init__.py
+++ b/PyISY/__init__.py
@@ -23,7 +23,7 @@ limitations under the License.
 
 from .ISY import ISY
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __author__ = 'Ryan M. Kraus'
 __email__ = 'rmkraus at gmail dot com'
-__date__ = 'December 2017'
+__date__ = 'September 2019'

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,21 @@
 from setuptools import setup, find_packages
 
+# read the contents of your README file
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.txt'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(
     name='PyISY',
-    version='1.1.1',
+    version='1.1.2',
     license='Apache License 2.0',
     url='http://automic.us/projects/pyisy',
-    download_url='https://github.com/automicus/pyisy/tarball/1.1.1',
     author='Ryan Kraus',
     author_email='automicus@gmail.com',
     description='Python module to talk to ISY994 from UDI.',
+    long_description=long_description,
+    long_description_content_type='text/plain',
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Removed deprecated download_url (which was 404 anyway) and added the long_description which pulls from the README per Python docs