### PR TITLE
Fix Programs throwing errors when ISY in 24-hour Clock Mode

### DIFF
--- a/PyISY/Programs/__init__.py
+++ b/PyISY/Programs/__init__.py
@@ -186,30 +186,26 @@ class Programs(object):
                     # last run time
                     try:
                         tag = 'lastRunTime'
-                        plastrun = feature.getElementsByTagName(tag)
-                        plastrun = plastrun[0].firstChild
-                        if plastrun is None:
-                            plastrun = _empty_time
+                        plastrun_str = feature.getElementsByTagName(tag)[0].firstChild.toxml()
+                        # ISY in Military Time uses 1 space in string, 12-hr Clock has 2 spaces
+                        if plastrun_str.count(' ') == 2:
+                            plastrun_fmt = '%Y/%m/%d %I:%M:%S %p'
                         else:
-                            plastrun = datetime.strptime(
-                                plastrun.toxml(), '%Y/%m/%d %I:%M:%S %p'
-                                if plastrun.toxml().count(' ') == 2
-                                else '%Y/%m/%d %H:%M:%S')
+                            plastrun_fmt = '%Y/%m/%d %H:%M:%S'
+                        plastrun = datetime.strptime(plastrun_str, plastrun_fmt)
                     except:
                         plastrun = _empty_time
 
                     # last finish time
                     try:
                         tag = 'lastFinishTime'
-                        plastfin = feature.getElementsByTagName(tag)
-                        plastfin = plastfin[0].firstChild
-                        if plastfin is None:
-                            plastfin = _empty_time
+                        plastfin_str = feature.getElementsByTagName(tag)[0].firstChild.toxml()
+                        # ISY in Military Time uses 1 space in string, 12-hr Clock has 2 spaces
+                        if plastfin_str.count(' ') == 2:
+                            plastfin_fmt = '%Y/%m/%d %I:%M:%S %p'
                         else:
-                            plastfin = datetime.strptime(
-                                plastfin.toxml(), '%Y/%m/%d %I:%M:%S %p'
-                                if plastfin.toxml().count(' ') == 2
-                                else '%Y/%m/%d %H:%M:%S')
+                            plastfin_fmt = '%Y/%m/%d %H:%M:%S'
+                        plastfin = datetime.strptime(plastfin_str, plastfin_fmt)
                     except:
                         plastfin = _empty_time
 

--- a/PyISY/Programs/__init__.py
+++ b/PyISY/Programs/__init__.py
@@ -192,7 +192,9 @@ class Programs(object):
                             plastrun = _empty_time
                         else:
                             plastrun = datetime.strptime(
-                                plastrun.toxml(), '%Y/%m/%d %I:%M:%S %p')
+                                plastrun.toxml(), '%Y/%m/%d %I:%M:%S %p'
+                                if plastrun.toxml().count(' ') == 2
+                                else '%Y/%m/%d %H:%M:%S')
                     except:
                         plastrun = _empty_time
 
@@ -205,7 +207,9 @@ class Programs(object):
                             plastfin = _empty_time
                         else:
                             plastfin = datetime.strptime(
-                                plastfin.toxml(), '%Y/%m/%d %I:%M:%S %p')
+                                plastfin.toxml(), '%Y/%m/%d %I:%M:%S %p'
+                                if plastfin.toxml().count(' ') == 2
+                                else '%Y/%m/%d %H:%M:%S')
                     except:
                         plastfin = _empty_time
 


### PR DESCRIPTION
The time string returned for Last Start and Last Finish times returned with the initial `/rest/programs' call varies depending on if the ISY is in 24-hr mode or not.

Originally reported [here](https://community.home-assistant.io/t/insteon-thermostat-2441th-for-isy/97821/53?u=shbatm).

This fix is a "patch" and just checks to see if there are 2 spaces in the time string. I have a more advanced (read: overkill) method staged for v2 which actually includes the `rest/time` endpoint and provides some additional ISY clock/date/location info.