### PR TITLE
[V2] Add ISY Clock and Location Information

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -194,7 +194,10 @@ class Nodes:
         prec = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_PREC, None)
         uom = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_UOM, None)
 
-        self.get_by_id(nid).controlEvents.notify(EventResult(cntrl, nval, prec, uom))
+        node = self.get_by_id(nid)
+        if not node: return
+
+        node.controlEvents.notify(EventResult(cntrl, nval, prec, uom))
         self.isy.log.debug("ISY Node Control Event: %s %s %s", nid, cntrl, nval)
 
     def parse(self, xml):
@@ -367,8 +370,12 @@ class Nodes:
 
         |  nid: Integer representing node/group/folder id.
         """
-        i = self.nids.index(nid)
-        return self.get_by_index(i)
+        try:
+            i = self.nids.index(nid)
+        except ValueError:
+            return None
+        else:
+            return self.get_by_index(i)
 
     def get_by_index(self, i):
         """

--- a/PyISY/Nodes/nodebase.py
+++ b/PyISY/Nodes/nodebase.py
@@ -77,7 +77,7 @@ class NodeBase:
             cmd = "DON"
         elif int(val) > 0:
             cmd = "DON"
-            val = str(val) if int(val) < 255 else None
+            val = str(val) if int(val) <= 255 else None
         else:
             cmd = "DOF"
             val = None
@@ -106,7 +106,7 @@ class NodeBase:
         )
 
         # Calculate hint to use if status is updated
-        hint = None
+        hint = self.status._val
         if cmd in ["DON", "DFON"]:
             hint = val if val is not None else 255
         if cmd in ["DOF", "DFOF"]:


### PR DESCRIPTION
Add a Clock class with the following properties exposed from the `/rest/time` endpoint:
 - last_called: the time of the last call to /rest/time
 - tz_offset: The Time Zone Offset of the ISY
 - dst: Daylight Savings Time Enabled or not
 - latitude: ISY Device Latitude
 - longitude: ISY Device Longitude
 - sunrise: ISY Calculated Sunrise
 - sunset: ISY Calculated Sunset
 - military: If the clock is military time or not.

The new class is used within PyISY primarily to determine if the ISY is using Military (24-hr) time or not. The new properties are exposed at `isy.clock` for external use and can be updated by calling `isy.clock.update()`. There is currently no automatic/periodic updating of this class and there are no automatic events received.