### PR TITLE
[V2] Add ISY Clock and Location Information

### DIFF
--- a/PyISY/Programs/__init__.py
+++ b/PyISY/Programs/__init__.py
@@ -208,12 +208,18 @@ class Programs:
                     # last run time
                     plastrun = value_from_xml(feature, "lastRunTime", EMPTY_TIME)
                     if plastrun != EMPTY_TIME:
-                        plastrun = datetime.strptime(plastrun, "%Y/%m/%d %I:%M:%S %p")
+                        plastrun = datetime.strptime(
+                            plastrun,
+                            MILITARY_TIME if self.isy.clock.military else STANDARD_TIME,
+                        )
 
                     # last finish time
                     plastfin = value_from_xml(feature, "lastFinishTime", EMPTY_TIME)
                     if plastfin != EMPTY_TIME:
-                        plastfin = datetime.strptime(plastfin, "%Y/%m/%d %I:%M:%S %p")
+                        plastfin = datetime.strptime(
+                            plastfin,
+                            MILITARY_TIME if self.isy.clock.military else STANDARD_TIME,
+                        )
 
                     # enabled, run at startup, running
                     penabled = bool(attr_from_element(feature, "enabled") == "true")

--- a/PyISY/Variables/__init__.py
+++ b/PyISY/Variables/__init__.py
@@ -12,6 +12,7 @@ from ..constants import (
     ATTR_VAL,
     ATTR_VAR,
     XML_PARSE_ERROR,
+    XML_STRPTIME,
 )
 from ..helpers import attr_from_element, attr_from_xml, value_from_xml
 from .variable import Variable
@@ -110,7 +111,7 @@ class Variables:
             init = value_from_xml(feature, ATTR_INIT)
             val = value_from_xml(feature, ATTR_VAL)
             ts_raw = value_from_xml(feature, ATTR_TS)
-            t_s = datetime.strptime(ts_raw, "%Y%m%d %H:%M:%S")
+            t_s = datetime.strptime(ts_raw, XML_STRPTIME)
             vname = self.vnames[vtype].get(vid, "")
 
             vobj = self.vobjs[vtype].get(vid)
@@ -154,7 +155,7 @@ class Variables:
             )
             ts_raw = value_from_xml(xmldoc, ATTR_TS)
             vobj.lastEdit.update(
-                datetime.strptime(ts_raw, "%Y%m%d %H:%M:%S"), force=True, silent=True
+                datetime.strptime(ts_raw, XML_STRPTIME), force=True, silent=True
             )
         self.isy.log.debug("ISY Updated Variable: %s", str(vid))
 

--- a/PyISY/clock.py
+++ b/PyISY/clock.py
@@ -1,0 +1,142 @@
+"""ISY Clock/Location Information."""
+from time import sleep
+from xml.dom import minidom
+
+from .constants import EMPTY_TIME, XML_PARSE_ERROR
+from .helpers import ntp_to_system_time, value_from_xml
+
+
+class Clock:
+    """
+    ISY Clock class cobject.
+
+    DESCRIPTION:
+        This class handles the ISY clock/location info.
+
+    ATTRIBUTES:
+        isy: The ISY device class
+        last_called: the time of the last call to /rest/time
+        tz_offset: The Time Zone Offset of the ISY
+        dst: Daylight Savings Time Enabled or not
+        latitude: ISY Device Latitude
+        longitude: ISY Device Longitude
+        sunrise: ISY Calculated Sunrise
+        sunset: ISY Calculated Sunset
+        military: If the clock is military time or not.
+
+    """
+
+    def __init__(self, isy, xml=None):
+        """
+        Initialize the network resources class.
+
+        isy: ISY class
+        xml: String of xml data containing the configuration data
+        """
+        self.isy = isy
+        self._last_called = EMPTY_TIME
+        self._tz_offset = 0
+        self._dst = False
+        self._latitude = 0.0
+        self._longitude = 0.0
+        self._sunrise = EMPTY_TIME
+        self._sunset = EMPTY_TIME
+        self._military = False
+
+        if xml is not None:
+            self.parse(xml)
+
+    def __str__(self):
+        """Return a string representing the clock Class."""
+        return "ISY Clock (Last Updated {!s})".format(self.last_called)
+
+    def __repr__(self):
+        """Return a long string showing all the clock values."""
+        props = [
+            name for name, value in vars(Clock).items() if isinstance(value, property)
+        ]
+        return "ISY Clock: {!r}".format(
+            {prop: str(getattr(self, prop)) for prop in props}
+        )
+
+    def parse(self, xml):
+        """
+        Parse the xml data.
+
+        xml: String of the xml data
+        """
+        try:
+            xmldoc = minidom.parseString(xml)
+        except (TypeError, KeyError):
+            self.isy.log.error("%s: Clock", XML_PARSE_ERROR)
+        else:
+            tz_offset_sec = int(value_from_xml(xmldoc, "TMZOffset"))
+            self._tz_offset = tz_offset_sec / 3600
+            self._dst = value_from_xml(xmldoc, "DST") == "true"
+            self._latitude = float(value_from_xml(xmldoc, "Lat"))
+            self._longitude = float(value_from_xml(xmldoc, "Long"))
+            self._military = value_from_xml(xmldoc, "IsMilitary") == "true"
+            self._last_called = ntp_to_system_time(int(value_from_xml(xmldoc, "NTP")))
+            self._sunrise = ntp_to_system_time(int(value_from_xml(xmldoc, "Sunrise")))
+            self._sunset = ntp_to_system_time(int(value_from_xml(xmldoc, "Sunset")))
+
+            self.isy.log.info("ISY Loaded Clock Information")
+
+    def update(self, wait_time=0):
+        """
+        Update the contents of the networking class.
+
+        wait_time: [optional] Amount of seconds to wait before updating
+        """
+        sleep(wait_time)
+        xml = self.isy.conn.get_time()
+        self.parse(xml)
+
+    def update_thread(self, interval):
+        """
+        Continually update the class until it is told to stop.
+
+        Should be run in a thread.
+        """
+        while self.isy.auto_update:
+            self.update(interval)
+
+    @property
+    def last_called(self):
+        """Get the time of the last call to /rest/time in UTC."""
+        return self._last_called
+
+    @property
+    def tz_offset(self):
+        """Provide the Time Zone Offset from the isy in Hours."""
+        return self._tz_offset
+
+    @property
+    def dst(self):
+        """Confirm if DST is enabled or not on the ISY."""
+        return self._dst
+
+    @property
+    def latitude(self):
+        """Provide the latitude information from the isy."""
+        return self._latitude
+
+    @property
+    def longitude(self):
+        """Provide the longitude information from the isy."""
+        return self._longitude
+
+    @property
+    def sunrise(self):
+        """Provide the sunrise information from the isy (UTC)."""
+        return self._sunrise
+
+    @property
+    def sunset(self):
+        """Provide the sunset information from the isy (UTC)."""
+        return self._sunset
+
+    @property
+    def military(self):
+        """Confirm if military time is in use or not on the isy."""
+        return self._military

--- a/PyISY/connection.py
+++ b/PyISY/connection.py
@@ -212,6 +212,12 @@ class Connection:
         result = self.request(req_url)
         return result
 
+    def get_time(self):
+        """Fetch the system time info from the ISY."""
+        req_url = self.compile_url(["time"])
+        result = self.request(req_url)
+        return result
+
 
 class TLSHttpAdapter(HTTPAdapter):
     """Transport adapter that uses TLS1."""

--- a/PyISY/constants.py
+++ b/PyISY/constants.py
@@ -2,6 +2,8 @@
 import datetime
 
 UPDATE_INTERVAL = 0.5
+
+# Time Constants / Strings
 EMPTY_TIME = datetime.datetime(year=1, month=1, day=1)
 ISY_EPOCH_OFFSET = 36524
 STANDARD_TIME = "%Y/%m/%d %I:%M:%S %p"

--- a/PyISY/helpers.py
+++ b/PyISY/helpers.py
@@ -1,4 +1,6 @@
 """Helper functions for the PyISY Module."""
+import datetime
+import time
 
 from .constants import (
     ATTR_FORMATTED,
@@ -7,6 +9,7 @@ from .constants import (
     ATTR_UOM,
     ATTR_VALUE,
     BATLVL_PROPERTY,
+    ISY_EPOCH_OFFSET,
     STATE_PROPERTY,
     VALUE_UNKNOWN,
 )
@@ -92,3 +95,25 @@ def attr_from_element(element, attr_name, default=None):
     if attr_name in element.attributes.keys():
         value = element.attributes[attr_name].value
     return value
+
+
+def ntp_to_system_time(timestamp):
+    """Convert a ISY NTP time to system UTC time.
+
+    Adapted from Python ntplib module.
+    https://pypi.org/project/ntplib/
+
+    Parameters:
+    timestamp -- timestamp in NTP time
+
+    Returns:
+    corresponding system time
+
+    Note: The ISY uses a EPOCH_OFFSET in addition to standard NTP.
+
+    """
+    _system_epoch = datetime.date(*time.gmtime(0)[0:3])
+    _ntp_epoch = datetime.date(1900, 1, 1)
+    ntp_delta = ((_system_epoch - _ntp_epoch).days * 24 * 3600) - ISY_EPOCH_OFFSET
+
+    return datetime.datetime.fromtimestamp(timestamp - ntp_delta)

--- a/PyISY/isy.py
+++ b/PyISY/isy.py
@@ -3,6 +3,7 @@ import logging
 from threading import Thread
 
 from .climate import Climate
+from .clock import Clock
 from .configuration import Configuration
 from .connection import Connection
 from .constants import COMMAND_FRIENDLY_NAME, UOM_TO_STATES, X10_COMMANDS
@@ -76,6 +77,7 @@ class ISY:
         else:
             self._connected = True
             self.configuration = Configuration(self, xml=self.conn.get_config())
+            self.clock = Clock(self, xml=self.conn.get_time())
             self._add_commands()
             self.nodes = Nodes(self, xml=self.conn.get_nodes())
             self.programs = Programs(self, xml=self.conn.get_programs())


### PR DESCRIPTION
 Add a Clock class with the following properties exposed from the `/rest/time` endpoint:
 - last_called: the time of the last call to /rest/time
 - tz_offset: The Time Zone Offset of the ISY
 - dst: Daylight Savings Time Enabled or not
 - latitude: ISY Device Latitude
 - longitude: ISY Device Longitude
 - sunrise: ISY Calculated Sunrise
 - sunset: ISY Calculated Sunset
 - military: If the clock is military time or not.

The new class is used within PyISY primarily to determine if the ISY is using Military (24-hr) time or not. The new properties are exposed at `isy.clock` for external use and can be updated by calling `isy.clock.update()`. There is currently no automatic/periodic updating of this class and there are no automatic events received.