### PR TITLE
[V2] Expose Firmware, UUID, and Hostname properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
 - Dynamically adds control functions to the Node and Program class--this is for future expansion to only add the appropriate commands to a given Node Type (e.g. don't add climate_mode to a light).
 - Adding retries for failed REST calls to the ISY #46
 - Adds increased Z-Wave support by storing the `devtype` category (since `type` is useless for Z-Wave)
+- Expose UUID, Firmware, and Hostname properties for referencing inside the `isy` object.
 
 #### Fixes:
 

--- a/PyISY/configuration.py
+++ b/PyISY/configuration.py
@@ -17,7 +17,8 @@ class Configuration(dict):
         dictionary with the either module names or ids
         being used as keys and a boolean indicating
         whether the module is installed will be
-        returned.
+        returned. With the exception of 'firmware' and 'uuid',
+        which will return their respective values.
 
     PARAMETERS:
         Portal Integration - Check-it.ca
@@ -73,6 +74,18 @@ class Configuration(dict):
         xml: String of the xml data
         """
         xmldoc = minidom.parseString(xml)
+
+        self["firmware"] = value_from_xml(xmldoc, "app_full_version")
+
+        try:
+            self["uuid"] = (
+                xmldoc.getElementsByTagName("root")[0]
+                .getElementsByTagName(ATTR_ID)[0]
+                .firstChild.toxml()
+            )
+        except IndexError:
+            self["uuid"] = None
+
         features = xmldoc.getElementsByTagName("feature")
 
         for feature in features:

--- a/PyISY/isy.py
+++ b/PyISY/isy.py
@@ -75,6 +75,7 @@ class ISY:
                 self.log.error(err.args[0])
 
         else:
+            self._hostname = address
             self._connected = True
             self.configuration = Configuration(self, xml=self.conn.get_config())
             self.clock = Clock(self, xml=self.conn.get_time())
@@ -115,6 +116,11 @@ class ISY:
         if self._events is not None:
             return self._events.running
         return False
+
+    @property
+    def hostname(self):
+        """Return the hostname."""
+        return self._hostname
 
     @auto_update.setter
     def auto_update(self, val):


### PR DESCRIPTION
Expose the hostname as `isy.hostname`.

Expose the UUID and Firmware from the existing Configuration call:
- isy.configuration.firmware
- isy.configuration.uuid

Update CHANGELOG

Note: this is setup for supporting multiple ISY controllers. Currently, there is no easy way to differentiate which ISY an individual Node class is attached to.