### PR TITLE
[V2] Rename message functions to be more descriptive.

### DIFF
--- a/PyISY/Nodes/__init__.py
+++ b/PyISY/Nodes/__init__.py
@@ -170,7 +170,7 @@ class Nodes:
         iter_data = self.all_lower_nodes
         return NodeIterator(self, iter_data, delta=-1)
 
-    def _upmsg(self, xmldoc):
+    def update_received(self, xmldoc):
         """Update nodes from event stream message."""
         nid = value_from_xml(xmldoc, ATTR_NODE)
         nval = int(value_from_xml(xmldoc, ATTR_ACTION))
@@ -185,7 +185,7 @@ class Nodes:
         self.get_by_id(nid).status.update(nval, force=True, silent=True)
         self.isy.log.debug("ISY Updated Node: " + nid)
 
-    def _controlmsg(self, xmldoc):
+    def control_message_received(self, xmldoc):
         """
         Pass Control events from an event stream message to nodes.
 

--- a/PyISY/Programs/__init__.py
+++ b/PyISY/Programs/__init__.py
@@ -140,7 +140,7 @@ class Programs:
         iter_data = self.all_lower_programs
         return ProgramIterator(self, iter_data, delta=-1)
 
-    def _upmsg(self, xmldoc):
+    def update_received(self, xmldoc):
         """Update programs from EventStream message."""
         xml = xmldoc.toxml()
         pid = value_from_xml(xmldoc, ATTR_ID).zfill(4)

--- a/PyISY/Variables/__init__.py
+++ b/PyISY/Variables/__init__.py
@@ -136,7 +136,8 @@ class Variables:
         xml = self.isy.conn.get_variables()
         self.parse(xml)
 
-    def _upmsg(self, xmldoc):
+    def update_received(self, xmldoc):
+        """Process an update received from the event stream."""
         xml = xmldoc.toxml()
         vtype = int(attr_from_xml(xmldoc, ATTR_VAR, ATTR_TYPE))
         vid = int(attr_from_xml(xmldoc, ATTR_VAR, ATTR_ID))

--- a/PyISY/climate.py
+++ b/PyISY/climate.py
@@ -296,7 +296,7 @@ class Climate:
         xml = self.isy.conn.get_climate()
         self.parse(xml)
 
-    def _upmsg(self, xmldoc):
+    def update_received(self, xmldoc):
         cid = int(value_from_xml(xmldoc, ATTR_ACTION)) - 1
         val_raw = value_from_xml(xmldoc, ATTR_VALUE, "").strip()
         unit_raw = value_from_xml(xmldoc, "unit", "").strip()


### PR DESCRIPTION
Rename _upmsg, _routemsg, _controlmsg to more descriptive names.

Also made public (removed `_` prefix) to make Lint happy since these are called externally in `events.py`.