### PR TITLE
[V2] Revert previous V2 change to dynamically add node commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,23 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
             uom = uom[0]
     ```
     
-- Node.lock() and Node.unlock() methods are now Node.secure_lock() and Node.secure_unlock().
-- Most functions *that should be internal only* have been renamed to snake_case from CamelCase.
-- Property `node.hasChildren` has been renamed to `node.has_children`.
-- Node Parent property has been renamed. Internal property is `node._parent_nid`, but externally accessible property is `node.parent_node`.
-- `node.controlEvents` has been renamed to `node.control_events`.
-- `variable.setInit` and `variable.set_value` have been renamed to `variable.set_init` and `variable.set_value`.
-- `ISY.sendX10` has been renamed to `ISY.send_x10_cmd`.
-- Network Resources `updateThread` function has been renamed to `update_threaded`.
-- Properties `nid`, `pid`, `nids`, `pids` have been renamed to `address` and `addresses` for consisitency. Variables still use `vid`; however, they also include an `address` property of the form `type.id`.
-- Node Functions `on()` and `off()` have been renamed to `turn_on()` and `turn_off()`
+- Functions and properties have been renamed to snake_case from CamelCase.
+  - Property `node.hasChildren` has been renamed to `node.has_children`.
+  - Node Parent property has been renamed. Internal property is `node._parent_nid`, but externally accessible property is `node.parent_node`.
+  - `node.controlEvents` has been renamed to `node.control_events`.
+  - `variable.setInit` and `variable.set_value` have been renamed to `variable.set_init` and `variable.set_value`.
+  - `ISY.sendX10` has been renamed to `ISY.send_x10_cmd`.
+  - Network Resources `updateThread` function has been renamed to `update_threaded`.
+  - Properties `nid`, `pid`, `nids`, `pids` have been renamed to `address` and `addresses` for consisitency. Variables still use `vid`; however, they also include an `address` property of the form `type.id`.
+  - Node Functions `on()` and `off()` have been renamed to `turn_on()` and `turn_off()`
+  - Node.lock() and Node.unlock() methods are now Node.secure_lock() and Node.secure_unlock().
+  - Node climate and fan speed functions have been reduced and require a proper command from UOM 98/99 (see `constants.py`):
+    + For example to activate PROGRAM AUTO mode, call `node.set_climate_mode("program_auto")`
+  - Program functions have been renamed:
+    + `runThen` -> `run_then`
+    + `runElse` -> `run_else`
+    + `enableRunAtStartup` -> `enable_run_at_startup`
+    + `disableRunAtStartup` -> `disable_run_at_startup`
 
 #### New:
 
@@ -42,6 +49,22 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
 - Adding retries for failed REST calls to the ISY #46
 - Adds increased Z-Wave support by storing the `devtype` category (since `type` is useless for Z-Wave)
 - Expose UUID, Firmware, and Hostname properties for referencing inside the `isy` object.
+- Various node commands have been renamed / newly exposed:
+    + `start_manual_dimming`
+    + `stop_manual_dimming`
+    + `set_climate_setpoint`
+    + `set_climate_setpoint_heat`
+    + `set_climate_setpoint_cool`
+    + `set_fan_speed`
+    + `set_climate_mode`
+    + `beep`
+    + `brighten`
+    + `dim`
+    + `fade_down`
+    + `fade_up`
+    + `fade_stop`
+    + `fast_on`
+    + `fast_off`
 
 #### Fixes:
 

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -260,30 +260,6 @@ EVENT_PROPS_IGNORED = [
 
 COMMAND_NAME = {val: key for key, val in COMMAND_FRIENDLY_NAME.items()}
 
-COMMANDS_PROGRAMS = [CMD_ENABLE_RUN_AT_STARTUP, CMD_DISABLE_RUN_AT_STARTUP]
-COMMANDS_FOLDERS = [
-    CMD_RUN,
-    CMD_RUN_THEN,
-    CMD_RUN_ELSE,
-    CMD_STOP,
-    CMD_ENABLE,
-    CMD_DISABLE,
-]
-
-COMMANDS_NODES = [
-    (CMD_BEEP, None),
-    (CMD_BRIGHTEN, None),
-    (CMD_CLIMATE_FAN_SPEED, "99"),
-    (CMD_CLIMATE_MODE, "98"),
-    (CMD_DIM, None),
-    (CMD_FADE_DOWN, None),
-    (CMD_FADE_STOP, None),
-    (CMD_FADE_UP, None),
-    (CMD_OFF_FAST, None),
-    (CMD_ON_FAST, None),
-    (CMD_SECURE, "84"),
-]
-
 # Referenced from ISY-WSDK-5.0.4\WSDL\family.xsd
 NODE_FAMILY_ID = {
     "0": "Default",
@@ -298,6 +274,10 @@ NODE_FAMILY_ID = {
     "9": "NCD",
     "10": "Node Server",
 }
+
+UOM_SECONDS = "57"
+UOM_FAN_SPEEDS = "99"
+UOM_CLIMATE_MODES = "98"
 
 UOM_FRIENDLY_NAME = {
     "1": "A",
@@ -589,3 +569,8 @@ INSTEON_RAMP_RATES = {
     "30": 0.2,
     "31": 0.1,
 }
+
+# Thermostat Types/Categories. 4.8 Trane, 5.3 venstar, 5.10 Insteon Wireless,
+#  5.11 Insteon, 5.17 Insteon (EU), 5.18 Insteon (Aus/NZ)
+THERMOSTAT_TYPES = ["4.8", "5.3", "5.10", "5.11", "5.17", "5.18"]
+THERMOSTAT_ZWAVE_CAT = ["140"]

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -14,6 +14,7 @@ from .constants import (
     PROP_RAMP_RATE,
     PROP_STATUS,
     TAG_PROPERTY,
+    UOM_SECONDS,
     VALUE_UNKNOWN,
 )
 

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -4,6 +4,12 @@ from xml.dom import minidom
 from VarEvents import Property
 
 from ..constants import (
+    CMD_BEEP,
+    CMD_BRIGHTEN,
+    CMD_DIM,
+    CMD_FADE_DOWN,
+    CMD_FADE_STOP,
+    CMD_FADE_UP,
     CMD_OFF,
     CMD_OFF_FAST,
     CMD_ON,
@@ -150,3 +156,35 @@ class NodeBase:
             hint = 0
         self.update(UPDATE_INTERVAL, hint=hint)
         return True
+
+    def beep(self):
+        """Identify physical device by sound (if supported)."""
+        return self.send_cmd(CMD_BEEP)
+
+    def brighten(self):
+        """Increase brightness of a device by ~3%."""
+        return self.send_cmd(CMD_BRIGHTEN)
+
+    def dim(self):
+        """Decrease brightness of a device by ~3%."""
+        return self.send_cmd(CMD_DIM)
+
+    def fade_down(self):
+        """Begin fading down (dim) a device."""
+        return self.send_cmd(CMD_FADE_DOWN)
+
+    def fade_up(self):
+        """Begin fading up (dim) a device."""
+        return self.send_cmd(CMD_FADE_UP)
+
+    def fade_stop(self):
+        """Stop fading a device."""
+        return self.send_cmd(CMD_FADE_STOP)
+
+    def fast_on(self):
+        """Start manually brightening a device."""
+        return self.send_cmd(CMD_ON_FAST)
+
+    def fast_off(self):
+        """Start manually brightening a device."""
+        return self.send_cmd(CMD_OFF_FAST)

--- a/pyisy/programs/folder.py
+++ b/pyisy/programs/folder.py
@@ -1,7 +1,18 @@
 """ISY Program Folders."""
 from VarEvents import Property
 
-from ..constants import PROTO_FOLDER, TAG_FOLDER, UPDATE_INTERVAL, URL_PROGRAMS
+from ..constants import (
+    CMD_DISABLE,
+    CMD_ENABLE,
+    CMD_RUN,
+    CMD_RUN_ELSE,
+    CMD_RUN_THEN,
+    CMD_STOP,
+    PROTO_FOLDER,
+    TAG_FOLDER,
+    UPDATE_INTERVAL,
+    URL_PROGRAMS,
+)
 
 
 class Folder:
@@ -74,3 +85,27 @@ class Folder:
     def protocol(self):
         """Return the protocol for this entity."""
         return PROTO_FOLDER
+
+    def run(self):
+        """Send a run command to the program/folder."""
+        return self.send_pgrm_cmd(CMD_RUN)
+
+    def run_then(self):
+        """Send a runThen command to the program/folder."""
+        return self.send_pgrm_cmd(CMD_RUN_THEN)
+
+    def run_else(self):
+        """Send a runElse command to the program/folder."""
+        return self.send_pgrm_cmd(CMD_RUN_ELSE)
+
+    def stop(self):
+        """Send a stop command to the program/folder."""
+        return self.send_pgrm_cmd(CMD_STOP)
+
+    def enable(self):
+        """Send command to the program/folder to enable it."""
+        return self.send_pgrm_cmd(CMD_ENABLE)
+
+    def disable(self):
+        """Send command to the program/folder to enable it."""
+        return self.send_pgrm_cmd(CMD_DISABLE)

--- a/pyisy/programs/program.py
+++ b/pyisy/programs/program.py
@@ -120,3 +120,11 @@ class Program(Folder):
     def protocol(self):
         """Return the protocol for this entity."""
         return PROTO_PROGRAM
+
+    def enable_run_at_startup(self):
+        """Send command to the program to enable it to run at startup."""
+        return self.send_pgrm_cmd(CMD_ENABLE_RUN_AT_STARTUP)
+
+    def disable_run_at_startup(self):
+        """Send command to the program to enable it to run at startup."""
+        return self.send_pgrm_cmd(CMD_DISABLE_RUN_AT_STARTUP)


### PR DESCRIPTION
Backtracking and reverting the changes made in #44 to dynamically add control functions to nodes and programs at run-time. 

The purpose of the original change was to reduce redundant code, and enable future blocking of certain commands from being run on devices that didn't support it (e.g. don't add the lock/unlock functions to a thermostat)--in reality, the dynamic functions just hurt readability of the code and makes it harder for others to integrate this module into other projects.

Instead, this change adds back the individual functions in a cleaner manner than V1 and adds the `node.is_thermostat` and `node.is_lock` properties for some known (easy) categories/sorting and shows warnings when trying to call commands on the incorrect type of device.