### PR TITLE
[V2] Better handling of Parent and Primary Node properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
     + `fade_stop`
     + `fast_on`
     + `fast_off`
+- In addition to the `node.parent_node` which returns a `Node` object if a node has a primary/parent node other than itself, there is now a `node.primary_node` property, which just returns the address of the primary node. If the device/group *is* the primary node, this is the same as the address (this is the `pnode` tag from `/rest/nodes`). 
 
 #### Fixes:
 

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -269,7 +269,7 @@ class Nodes:
                 address = value_from_xml(feature, TAG_ADDRESS)
                 nname = value_from_xml(feature, TAG_NAME)
                 nparent = value_from_xml(feature, TAG_PARENT)
-                parent_nid = value_from_xml(feature, TAG_PRIMARY_NODE)
+                pnode = value_from_xml(feature, TAG_PRIMARY_NODE)
                 family = value_from_xml(feature, TAG_FAMILY)
                 device_type = value_from_xml(feature, TAG_TYPE)
                 node_def_id = attr_from_element(feature, ATTR_NODE_DEF_ID)
@@ -318,7 +318,7 @@ class Nodes:
                             aux_properties=aux_props,
                             devtype_cat=devtype_cat,
                             node_def_id=node_def_id,
-                            parent_nid=parent_nid,
+                            pnode=pnode,
                             device_type=device_type,
                             enabled=enabled,
                             node_server=node_server,
@@ -350,7 +350,15 @@ class Nodes:
                         address,
                         nname,
                         nparent,
-                        Group(self, address, nname, members, controllers),
+                        Group(
+                            self,
+                            address=address,
+                            name=nname,
+                            members=members,
+                            controllers=controllers,
+                            family_id=family,
+                            pnode=pnode,
+                        ),
                         ntype,
                     )
             self.isy.log.debug("ISY Loaded {}".format(ntype))

--- a/pyisy/nodes/group.py
+++ b/pyisy/nodes/group.py
@@ -26,11 +26,20 @@ class Group(NodeBase):
 
     group_all_on = Property(False)
 
-    def __init__(self, nodes, address, name, members=None, controllers=None):
+    def __init__(
+        self,
+        nodes,
+        address,
+        name,
+        members=None,
+        controllers=None,
+        family_id="6",
+        pnode=None,
+    ):
         """Initialize a Group class."""
         self._members = members or []
         self._controllers = controllers or []
-        super().__init__(nodes, address, name, family_id="6")
+        super().__init__(nodes, address, name, family_id=family_id, pnode=pnode)
 
         # listen for changes in children
         self._members_handlers = [

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -44,7 +44,7 @@ class Node(NodeBase):
     |  aux_properties: Additional Properties for the node
     |  devtype_cat: Device Type Category (used for Z-Wave Nodes.)
     |  node_def_id: Node Definition ID (used for ISY firmwares >=v5)
-    |  parent_nid: Node ID of the parent node
+    |  pnode: Node ID of the primary node
     |  device_type: device type.
     |  node_server: the parent node server slot used
     |  protocol: the device protocol used (z-wave, zigbee, insteon, node server)
@@ -63,7 +63,7 @@ class Node(NodeBase):
         aux_properties=None,
         devtype_cat=None,
         node_def_id=None,
-        parent_nid=None,
+        pnode=None,
         device_type=None,
         enabled=None,
         node_server=None,
@@ -75,7 +75,7 @@ class Node(NodeBase):
         self._node_def_id = node_def_id
         self._type = device_type
         self._enabled = enabled if enabled is not None else True
-        self._parent_nid = parent_nid if parent_nid != address else None
+        self._parent_node = pnode if pnode != address else None
         self._uom = state.uom
         self._prec = state.prec
         self._formatted = state.formatted
@@ -84,7 +84,12 @@ class Node(NodeBase):
         self.status.update(state.value, force=True, silent=True)
         self.control_events = EventEmitter()
         super().__init__(
-            nodes, address, name, family_id=family_id, aux_properties=aux_properties
+            nodes,
+            address,
+            name,
+            family_id=family_id,
+            aux_properties=aux_properties,
+            pnode=pnode,
         )
 
     @property
@@ -230,8 +235,8 @@ class Node(NodeBase):
         Return None if there is no parent.
 
         """
-        if self._parent_nid:
-            return self._nodes.get_by_id(self._parent_nid)
+        if self._parent_node:
+            return self._nodes.get_by_id(self._parent_node)
         return None
 
     def get_command_value(self, uom, cmd):

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -33,13 +33,16 @@ class NodeBase:
     status = Property(0)
     has_children = False
 
-    def __init__(self, nodes, address, name, family_id=None, aux_properties=None):
+    def __init__(
+        self, nodes, address, name, family_id=None, aux_properties=None, pnode=None
+    ):
         """Initialize a Group class."""
         self._nodes = nodes
         self.isy = nodes.isy
         self._id = address
         self._name = name
         self._notes = None
+        self._primary_node = pnode
         self._aux_properties = aux_properties if aux_properties is not None else {}
         self._family = NODE_FAMILY_ID.get(family_id)
 
@@ -84,6 +87,16 @@ class NodeBase:
             else:
                 spoken = value_from_xml(notesdom, TAG_SPOKEN)
         return {TAG_SPOKEN: spoken}
+
+    @property
+    def primary_node(self):
+        """Return just the parent/primary node address.
+
+        This is similar to Node.parent_node but does not return the whole Node
+        class, and will return itself if it is the primary node/group.
+
+        """
+        return self._primary_node
 
     @property
     def spoken(self):


### PR DESCRIPTION
Previously only the physical "Parent" node was exposed if it existed. This change exposes the "Primary" (corrected name from ISY WSDK) node address, regardless of if it is different from the node address or not (for most devices, the primary node is the same).  The "Parent" node is still returned the same as it previously was, as it is still useful to have access to the primary node's object and functions for things like motion sensors and leak detection. This will also be important if Z-Wave compatibility is expanded, since the ISY likes to break up Z-Wave devices into multiple sub-nodes.

Sets up for Device Grouping in Home Assistant as well as future solution to automacus/PyISY#11