### PR TITLE
[V2] Add Pre-Commit Config for Black, iSort, Flake8, and Codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+---
+repos:
+  - hooks:
+      - args: [--safe, --quiet]
+        files: ^((pyisy)/.+)?[^/]+\.py$
+        id: black
+    repo: https://github.com/psf/black
+    rev: 19.10b0
+  - hooks:
+      - args: ['--ignore-words-list=pyisy,hass,isy,nid,dof,dfof,don,dfon',
+               '--skip="./.*,*.json"', --quiet-level=2]
+        exclude_types: [json]
+        id: codespell
+    repo: https://github.com/codespell-project/codespell
+    rev: v1.16.0
+  - hooks:
+      - additional_dependencies: [flake8-docstrings==1.5.0, pydocstyle==5.0.2]
+        files: ^(pyisy)/((?!climate).)+\.py$
+        id: flake8
+    repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+  - hooks:
+      - {id: isort}
+    repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ monitored automatically as changes are reported from the device.
 
 * Greg Laabs ([@OverloadUT])
 * Ryan Kraus ([@rmkraus]) (creator)
+
+### Contributing
+
+A note on contributing: contributions of any sort are more than welcome! This repo uses precommit hooks to validate all code. We use `black` to format our code, `isort` to sort our imports, `flake8` for linting and syntax checks, and `codespell` for spell check.
+
+To use [pre-commit](https://pre-commit.com/#installation), see the installation instructions for more details.
+
+Short version:
+
+```shell
+# From your copy of the pyisy repo folder:
+pip install pre-commit
+pre-commit install
+```

--- a/pyisy/__init__.py
+++ b/pyisy/__init__.py
@@ -30,6 +30,7 @@ try:
 except (pkg_resources.ResolutionError, pkg_resources.ExtractionError):
     __version__ = "unknown"
 
+__all__ = ["ISY"]
 __author__ = "Ryan M. Kraus"
 __email__ = "rmkraus at gmail dot com"
 __date__ = "February 2020"

--- a/pyisy/configuration.py
+++ b/pyisy/configuration.py
@@ -4,18 +4,18 @@ from xml.dom import minidom
 from .constants import (
     ATTR_DESC,
     ATTR_ID,
+    TAG_DESC,
     TAG_FEATURE,
     TAG_FIRMWARE,
     TAG_INSTALLED,
-    XML_TRUE,
-    TAG_ROOT,
     TAG_NAME,
-    TAG_DESC,
-    TAG_PRODUCT,
     TAG_NODE_DEFS,
+    TAG_PRODUCT,
+    TAG_ROOT,
     TAG_VARIABLES,
+    XML_TRUE,
 )
-from .helpers import value_from_xml, value_from_nested_xml
+from .helpers import value_from_nested_xml, value_from_xml
 
 
 class Configuration(dict):
@@ -57,9 +57,9 @@ class Configuration(dict):
         NorthWrite NOC Module
 
     EXAMPLE:
-        >>> configuration['Networking Module']
+        # configuration['Networking Module']
         True
-        >>> configuration['21040']
+        # configuration['21040']
         True
 
     ATTRIBUTES:

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -130,7 +130,7 @@ class Connection:
             )
         except requests.ConnectionError:
             self.isy.log.error(
-                "ISY Could not recieve response "
+                "ISY Could not receive response "
                 "from device because of a network "
                 "issue."
             )
@@ -140,13 +140,13 @@ class Connection:
             return None
 
         if req.status_code == 200:
-            self.isy.log.debug("ISY Response Recieved")
+            self.isy.log.debug("ISY Response Received")
             # remove unicode from string in python 2.7, 3.2,
             # and 3.4 compatible way
             xml = "".join(char for char in req.text if ord(char) < 128)
             return xml
         if req.status_code == 404 and ok404:
-            self.isy.log.debug("ISY Response Recieved")
+            self.isy.log.debug("ISY Response Received")
             return ""
 
         self.isy.log.warning(

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -1,20 +1,15 @@
 """Connection to the ISY."""
-try:
-    # python 2.7
-    from urllib import quote
-    from urllib import urlencode
-except ImportError:
-    # python 3.4
-    from urllib.parse import quote
-    from urllib.parse import urlencode
 import base64
 import ssl
 import sys
 import time
+from urllib.parse import quote, urlencode
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+from urllib3 import disable_warnings
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3.poolmanager import PoolManager
 
 from .constants import (
     METHOD_GET,
@@ -58,7 +53,7 @@ class Connection:
                 self.use_https = True
                 self._tls_ver = tls_ver
                 # Most SSL certs will not be valid. Let's not warn about them.
-                requests.packages.urllib3.disable_warnings()
+                disable_warnings(InsecureRequestWarning)
 
                 # ISY uses TLS1 and not SSL
                 self.req_session.mount(self.compile_url(None), TLSHttpAdapter(tls_ver))
@@ -86,14 +81,8 @@ class Connection:
     def connection_info(self):
         """Return the connection info required to connect to the ISY."""
         connection_info = {}
-        authstr = "{!s}:{!s}".format(self._username, self._password)
-        try:
-            connection_info["auth"] = base64.encodestring(authstr).strip()
-        except TypeError:
-            authstr = bytes(authstr, "ascii")
-            connection_info["auth"] = (
-                base64.encodebytes(authstr).strip().decode("ascii")
-            )
+        authstr = bytes(f"{self._username}:{self._password}", "ascii")
+        connection_info["auth"] = base64.encodebytes(authstr).strip().decode("ascii")
         connection_info["addr"] = self._address
         connection_info["port"] = int(self._port)
         connection_info["passwd"] = self._password
@@ -266,12 +255,7 @@ def can_https(log, tls_ver):
     output = True
 
     # check python version
-    py_version = sys.version_info
-    if py_version.major == 3:
-        req_version = (3, 4)
-    else:
-        req_version = (2, 7, 9)
-    if py_version < req_version:
+    if sys.version_info < (3, 7):
         log.error("PyISY cannot use HTTPS: Invalid Python version. See docs.")
         output = False
 

--- a/pyisy/events.py
+++ b/pyisy/events.py
@@ -4,8 +4,8 @@ import select
 import socket
 import ssl
 import sys
-import xml
 from threading import Thread, ThreadError
+import xml
 from xml.dom import minidom
 
 from . import strings
@@ -206,7 +206,7 @@ class EventStream:
 
     @property
     def connected(self):
-        """Return if the module is connnected to the ISY or not."""
+        """Return if the module is connected to the ISY or not."""
         return self._connected
 
     @property

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -189,7 +189,7 @@ class NodeProperty(dict):
     __repr__ = __str__
 
     def __getattr__(self, name):
-        """Retreive the properties."""
+        """Retrieve the properties."""
         return self[name]
 
     def __setattr__(self, name, value):

--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -28,8 +28,8 @@ class NetworkResources:
         networking command class will be returned.
 
     EXAMPLE:
-        >>> a = networking['test function']
-        >>> a.run()
+        # a = networking['test function']
+        # a.run()
 
     ATTRIBUTES:
         isy: The ISY device class

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -6,17 +6,13 @@ from ..constants import (
     ATTR_ACTION,
     ATTR_CONTROL,
     ATTR_FLAG,
-    ATTR_FORMATTED,
-    ATTR_ID,
     ATTR_INSTANCE,
     ATTR_NODE_DEF_ID,
     ATTR_PRECISION,
     ATTR_UNIT_OF_MEASURE,
-    ATTR_VALUE,
     EVENT_PROPS_IGNORED,
     INSTEON_RAMP_RATES,
     PROP_RAMP_RATE,
-    PROTO_GROUP,
     PROTO_INSTEON,
     PROTO_NODE_SERVER,
     PROTO_ZIGBEE,
@@ -45,8 +41,8 @@ from ..helpers import (
     attr_from_element,
     attr_from_xml,
     parse_xml_properties,
-    value_from_xml,
     value_from_nested_xml,
+    value_from_xml,
 )
 from .group import Group
 from .node import Node
@@ -329,7 +325,7 @@ class Nodes:
                     # that is a ISY scene that contains every device/
                     # scene so it will contain some scenes we have not
                     # seen yet so they are not defined and it includes
-                    # the ISY MAC addrees in newer versions of
+                    # the ISY MAC address in newer versions of
                     # ISY firmwares > 5.0.6+ ..
                     if int(flag) & 0x08:
                         self.isy.log.info("Skipping group flag=%s %s", flag, address)

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -3,7 +3,6 @@ from time import sleep
 from xml.dom import minidom
 
 from ..constants import (
-    ATTR_UNIT_OF_MEASURE,
     CLIMATE_SETPOINT_MIN_GAP,
     CMD_CLIMATE_FAN_SPEED,
     CMD_CLIMATE_MODE,
@@ -241,7 +240,7 @@ class Node(NodeBase):
 
     def get_command_value(self, uom, cmd):
         """Check against the list of UOM States if this is a valid command."""
-        if not cmd in UOM_TO_STATES[uom].values():
+        if cmd not in UOM_TO_STATES[uom].values():
             self.isy.log.warning(
                 "Failed to call %s on %s, invalid command.", cmd, self.address
             )

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -313,7 +313,7 @@ class Programs:
                 try:
                     val = int(val)
                     fun = self.get_by_index
-                except:
+                except (TypeError, ValueError):
                     raise KeyError("Unrecognized Key: " + str(val))
 
         try:

--- a/pyisy/programs/folder.py
+++ b/pyisy/programs/folder.py
@@ -33,7 +33,7 @@ class Folder:
     dtype = TAG_FOLDER
 
     def __init__(self, programs, address, pname, pstatus):
-        """Intialize the Folder class."""
+        """Initialize the Folder class."""
         self.noupdate = False
         self._programs = programs
         self.isy = programs.isy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[tool:pytest]
+testpaths = tests
+norecursedirs = .git testing_config
+
+[flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+doctests = True
+# To work with Black
+max-line-length = 88
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+    W504
+
+[isort]
+# https://github.com/timothycrosley/isort
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# splits long import on multiple lines indented by 4 spaces
+multi_line_output = 3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+indent = "    "
+# by default isort don't check module indexes
+not_skip = __init__.py
+# will group `import x` and `from x import` of the same module.
+force_sort_within_sections = true
+sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = homeassistant,tests
+forced_separate = tests
+combine_as_imports = true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Module Setup File for PIP Installation."""
 
 import pathlib
+
 from setuptools import find_packages, setup
 
 HERE = pathlib.Path(__file__).parent


### PR DESCRIPTION
This adds `pre-commit` tests and repos for `black`, `isort`, `flake8`, and `codespell`.

To use:
```shell
pip install pre-commit
pre-commit install

pre-commit run --all-files
```