### PR TITLE
[V2] Improved Consistency in Error Handling, Fix Type Inconsistency

### DIFF
--- a/pyisy/clock.py
+++ b/pyisy/clock.py
@@ -12,6 +12,7 @@ from .constants import (
     TAG_SUNRISE,
     TAG_SUNSET,
     TAG_TZ_OFFSET,
+    XML_ERRORS,
     XML_PARSE_ERROR,
     XML_TRUE,
 )
@@ -79,7 +80,7 @@ class Clock:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+        except XML_ERRORS:
             self.isy.log.error("%s: Clock", XML_PARSE_ERROR)
         else:
             tz_offset_sec = int(value_from_xml(xmldoc, TAG_TZ_OFFSET))

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -1,8 +1,10 @@
 """Constants for the PyISY Module."""
 import datetime
+from xml.parsers.expat import ExpatError
 
 UPDATE_INTERVAL = 0.5
 VERBOSE = 5  # Verbose Logging Level
+
 
 # Time Constants / Strings
 EMPTY_TIME = datetime.datetime(year=1, month=1, day=1)
@@ -23,6 +25,7 @@ THREAD_SLEEP_TIME = 30.0
 
 ISY_VALUE_UNKNOWN = -1 * float("inf")
 
+XML_ERRORS = (AttributeError, KeyError, ValueError, TypeError, IndexError, ExpatError)
 XML_PARSE_ERROR = "ISY Could not parse response, poorly formatted XML."
 
 """ Dictionary of X10 commands. """

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -20,6 +20,7 @@ from .constants import (
     TAG_MFG,
     TAG_PROPERTY,
     UOM_SECONDS,
+    XML_ERRORS,
 )
 
 
@@ -78,7 +79,7 @@ def value_from_xml(xml, tag_name, default=None):
     value = default
     try:
         value = xml.getElementsByTagName(tag_name)[0].firstChild.toxml()
-    except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+    except XML_ERRORS:
         pass
     return value
 
@@ -89,7 +90,7 @@ def attr_from_xml(xml, tag_name, attr_name, default=None):
     try:
         root = xml.getElementsByTagName(tag_name)[0]
         value = attr_from_element(root, attr_name, default)
-    except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+    except XML_ERRORS:
         pass
     return value
 
@@ -115,7 +116,7 @@ def value_from_nested_xml(base, chain, default=None):
         if len(chain) > 3:
             result = result.getElementsByTagName(chain[3])[0]
         value = result.firstChild.toxml()
-    except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+    except XML_ERRORS:
         pass
     return value
 

--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -9,6 +9,7 @@ from .constants import (
     THREAD_SLEEP_TIME,
     URL_NETWORK,
     URL_RESOURCES,
+    XML_ERRORS,
     XML_PARSE_ERROR,
 )
 from .helpers import value_from_xml
@@ -63,7 +64,7 @@ class NetworkResources:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+        except XML_ERRORS:
             self.isy.log.error("%s: NetworkResources", XML_PARSE_ERROR)
         else:
             features = xmldoc.getElementsByTagName(TAG_NET_RULE)

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -33,6 +33,7 @@ from ..constants import (
     TAG_TYPE,
     UOM_SECONDS,
     URL_STATUS,
+    XML_ERRORS,
     XML_PARSE_ERROR,
     XML_TRUE,
 )
@@ -252,7 +253,7 @@ class Nodes:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+        except XML_ERRORS:
             self.isy.log.error("%s: Nodes", XML_PARSE_ERROR)
             return False
 

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -12,6 +12,7 @@ from ..constants import (
     ATTR_UNIT_OF_MEASURE,
     EVENT_PROPS_IGNORED,
     INSTEON_RAMP_RATES,
+    ISY_VALUE_UNKNOWN,
     PROP_RAMP_RATE,
     PROTO_INSTEON,
     PROTO_NODE_SERVER,
@@ -192,7 +193,8 @@ class Nodes:
     def update_received(self, xmldoc):
         """Update nodes from event stream message."""
         address = value_from_xml(xmldoc, TAG_NODE)
-        value = int(value_from_xml(xmldoc, ATTR_ACTION))
+        value = value_from_xml(xmldoc, ATTR_ACTION)
+        value = int(value) if value != "" else ISY_VALUE_UNKNOWN
         prec = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_PRECISION, "0")
         uom = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_UNIT_OF_MEASURE, "")
         node = self.get_by_id(address)
@@ -218,6 +220,7 @@ class Nodes:
 
         # Process the action and value if provided in event data.
         value = value_from_xml(xmldoc, ATTR_ACTION, 0)
+        value = int(value) if value != "" else ISY_VALUE_UNKNOWN
         prec = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_PRECISION, "0")
         uom = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_UNIT_OF_MEASURE, "")
         formatted = value_from_xml(xmldoc, TAG_FORMATTED)

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -24,6 +24,7 @@ from ..constants import (
     UOM_FAN_MODES,
     UOM_TO_STATES,
     URL_NODES,
+    XML_ERRORS,
     XML_PARSE_ERROR,
 )
 from ..helpers import EventEmitter, parse_xml_properties
@@ -198,7 +199,7 @@ class Node(NodeBase):
             xml = self.isy.conn.request(req_url)
             try:
                 xmldoc = minidom.parseString(xml)
-            except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+            except XML_ERRORS:
                 self.isy.log.error("%s: Nodes", XML_PARSE_ERROR)
                 return
         elif hint is not None:

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -25,6 +25,7 @@ from ..constants import (
     UPDATE_INTERVAL,
     URL_NODES,
     URL_NOTES,
+    XML_ERRORS,
     XML_PARSE_ERROR,
     XML_TRUE,
 )
@@ -149,7 +150,7 @@ class NodeBase:
         if notes_xml is not None and notes_xml != "":
             try:
                 notesdom = minidom.parseString(notes_xml)
-            except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+            except XML_ERRORS:
                 self.isy.log.error("%s: Node Notes %s", XML_PARSE_ERROR, notes_xml)
             else:
                 spoken = value_from_xml(notesdom, TAG_SPOKEN)

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -192,7 +192,7 @@ class NodeBase:
         hint = self.status
         if cmd == CMD_ON:
             if val is not None:
-                hint = val
+                hint = int(val)
             elif PROP_ON_LEVEL in self._aux_properties:
                 hint = self._aux_properties[PROP_ON_LEVEL].value
             else:

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -320,8 +320,8 @@ class Programs:
                 try:
                     val = int(val)
                     fun = self.get_by_index
-                except (TypeError, ValueError):
-                    raise KeyError("Unrecognized Key: " + str(val))
+                except (TypeError, ValueError) as err:
+                    raise KeyError("Unrecognized Key: " + str(val)) from err
 
         try:
             return fun(val)

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -19,6 +19,7 @@ from ..constants import (
     TAG_PRGM_STATUS,
     TAG_PROGRAM,
     UPDATE_INTERVAL,
+    XML_ERRORS,
     XML_OFF,
     XML_ON,
     XML_PARSE_ERROR,
@@ -200,7 +201,7 @@ class Programs:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+        except XML_ERRORS:
             self.isy.log.error("%s: Programs", XML_PARSE_ERROR)
         else:
             plastup = datetime.now()

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -12,6 +12,7 @@ from ..constants import (
     TAG_NAME,
     TAG_TYPE,
     TAG_VARIABLE,
+    XML_ERRORS,
     XML_PARSE_ERROR,
     XML_STRPTIME,
 )
@@ -97,7 +98,7 @@ class Variables:
                 continue
             try:
                 xmldoc = minidom.parseString(xmls[ind])
-            except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+            except XML_ERRORS:
                 self.isy.log.error("%s: Type %s Variables", XML_PARSE_ERROR, ind + 1)
                 continue
 
@@ -110,7 +111,7 @@ class Variables:
         """Parse XML from the controller with details about the variables."""
         try:
             xmldoc = minidom.parseString(xml)
-        except (AttributeError, KeyError, ValueError, TypeError, IndexError):
+        except XML_ERRORS:
             self.isy.log.error("%s: Variables", XML_PARSE_ERROR)
             return
 

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -179,8 +179,8 @@ class Variables:
         if isinstance(val, int):
             try:
                 return self.vobjs[self.root][val]
-            except (ValueError, KeyError):
-                raise KeyError(f"Unrecognized variable id: {val}")
+            except (ValueError, KeyError) as err:
+                raise KeyError(f"Unrecognized variable id: {val}") from err
         else:
             for vid, vname in self.vnames[self.root]:
                 if vname == val:


### PR DESCRIPTION
- Make all status and property values return integers instead of sometimes integer, sometimes string.
- Use a constant for the XML Parsing Error types, and include ExpatError
- Use nested errors instead of raising a new error inside of an error handler.