### PR TITLE
[V2] Use Instance instead of Class Variables To Support Multiple ISYs

### DIFF
--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -40,10 +40,6 @@ class NetworkResources:
 
     """
 
-    addresses = []
-    nnames = []
-    nobjs = []
-
     def __init__(self, isy, xml=None):
         """
         Initialize the network resources class.
@@ -52,6 +48,10 @@ class NetworkResources:
         xml: String of xml data containing the configuration data
         """
         self.isy = isy
+
+        self.addresses = []
+        self.nnames = []
+        self.nobjs = []
 
         if xml is not None:
             self.parse(xml)

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -73,12 +73,6 @@ class Nodes:
     :ivar name: The name of the current folder in navigation.
     """
 
-    addresses = []
-    nnames = []
-    nparents = []
-    nobjs = []
-    ntypes = []
-
     def __init__(
         self,
         isy,
@@ -94,22 +88,21 @@ class Nodes:
         self.isy = isy
         self.root = root
 
-        if (
-            addresses is not None
-            and nnames is not None
-            and nparents is not None
-            and nobjs is not None
-            and ntypes is not None
-        ):
+        self.addresses = []
+        self.nnames = []
+        self.nparents = []
+        self.nobjs = []
+        self.ntypes = []
 
-            self.addresses = addresses
-            self.nnames = nnames
-            self.nparents = nparents
-            self.nobjs = nobjs
-            self.ntypes = ntypes
-
-        elif xml is not None:
+        if xml is not None:
             self.parse(xml)
+            return
+
+        self.addresses = addresses
+        self.nnames = nnames
+        self.nparents = nparents
+        self.nobjs = nobjs
+        self.ntypes = ntypes
 
     def __str__(self):
         """Return string representation of the nodes/folders/groups."""

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -59,12 +59,6 @@ class Programs:
     :ivar name: The name of the program at the current level of navigation.
     """
 
-    addresses = []
-    pnames = []
-    pparents = []
-    pobjs = []
-    ptypes = []
-
     def __init__(
         self,
         isy,
@@ -80,21 +74,21 @@ class Programs:
         self.isy = isy
         self.root = root
 
-        if (
-            addresses is not None
-            and pnames is not None
-            and pparents is not None
-            and pobjs is not None
-            and ptypes is not None
-        ):
-            self.addresses = addresses
-            self.pnames = pnames
-            self.pparents = pparents
-            self.pobjs = pobjs
-            self.ptypes = ptypes
+        self.addresses = []
+        self.pnames = []
+        self.pparents = []
+        self.pobjs = []
+        self.ptypes = []
 
-        elif xml is not None:
+        if xml is not None:
             self.parse(xml)
+            return
+
+        self.addresses = addresses
+        self.pnames = pnames
+        self.pparents = pparents
+        self.pobjs = pobjs
+        self.ptypes = ptypes
 
     def __str__(self):
         """Return a string representation of the program manager."""

--- a/pyisy/programs/program.py
+++ b/pyisy/programs/program.py
@@ -163,12 +163,12 @@ class Program(Folder):
         |  data: [optional] Data to update the object with.
         """
         if data is not None:
-            self.enabled = data["penabled"]
-            self.last_finished = data["plastfin"]
-            self.last_run = data["plastrun"]
-            self.last_update = data["plastup"]
-            self.run_at_startup = data["pstartrun"]
-            self.running = (data["plastrun"] >= data["plastup"]) or data["prunning"]
+            self._enabled = data["penabled"]
+            self._last_finished = data["plastfin"]
+            self._last_run = data["plastrun"]
+            self._last_update = data["plastup"]
+            self._run_at_startup = data["pstartrun"]
+            self._running = (data["plastrun"] >= data["plastup"]) or data["prunning"]
             # Update Status last and make sure the change event fires, but only once.
             if self.status != data["pstatus"]:
                 self.status = data["pstatus"]

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -45,10 +45,6 @@ class Variables:
     :ivar children: List of the children below the current level of navigation.
     """
 
-    vids = {1: [], 2: []}
-    vobjs = {1: {}, 2: {}}
-    vnames = {1: {}, 2: {}}
-
     def __init__(
         self,
         isy,
@@ -62,6 +58,10 @@ class Variables:
         """Initialize a Variables ISY Variable Manager class."""
         self.isy = isy
         self.root = root
+
+        self.vids = {1: [], 2: []}
+        self.vobjs = {1: {}, 2: {}}
+        self.vnames = {1: {}, 2: {}}
 
         if vids is not None and vnames is not None and vobjs is not None:
             self.vids = vids


### PR DESCRIPTION
Eliminate the use of Class variables in favor of Instance Variables. Using Class Variables for the navigator classes causes an issue when multiple ISYs are in use.  Only one instance of PyISY is loaded, so it attempt to share the same lists for all instances of the ISY class. When multiple ISYs are connected in the same program, this causes errors.
