### PR TITLE
Add connection events target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 # PyBuilder
 target/
 .AppleDouble
+
+# VSCode Configs
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.formatting.provider": "black"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.linting.pylintEnabled": true,
-    "python.formatting.provider": "black"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## CHANGELOG
 
-### [v2.0.0] - Version 2.0 Initial Release
+### [v2.0.3] - Minor Updates, Connection Events and Timestamps
 
-#### Summary: 
+#### Added
+
+- Add connection events for the Event Stream to allow subscription and callbacks. Attach a callback with `isy.connection_events(callback)` and receive a string with the event detail. See `constants.py` for events starting with prefix `ES_`.
+
+### [v2.0.2] - Version 2.0 Initial Release
+
+#### Summary:
 
 V2 is a significant refactoring and cleanup of the original PyISY code, with the primary goal of (1) fixing as many bugs in one shot as possible and (2) moving towards PEP8 compliant code with as few breaking changes as possible.
 
@@ -16,13 +22,13 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
 - Node Unit of Measure is returned as a string if it is not a list of UOMs, otherwise it is returned as a list. Previously this was returned as a 1-item list if there was only 1 UOM.
     - ISYv4 and before returned the UOM as a string ('%/on/off' or 'degrees'), ISYv5 phases this out and uses numerical UOMs that correspond to a defined value in the SDK (included in constants file).
     - Previous implementations of `unit = uom[0]` should be replaced with `unit = uom` and for compatibility, UOM should be checked if it is a list with `isinstance(uom, list)`.
-    
+
     ```python
         uom = self._node.uom
         if isinstance(uom, list):
             uom = uom[0]
     ```
-    
+
 - Functions and properties have been renamed to snake_case from CamelCase.
   - Property `node.hasChildren` has been renamed to `node.has_children`.
   - Node Parent property has been renamed. Internal property is `node._parent_nid`, but externally accessible property is `node.parent_node`.
@@ -80,7 +86,7 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
         log=None,
         webroot="/isy/unique_isy_url_code_from_portal",
     )
-    # Unique URL can be found in ISY Portal under 
+    # Unique URL can be found in ISY Portal under
     #   Tools > Information > ISY Information
     ```
 - Adds increased Z-Wave support by returning Z-Wave Properties under the `Node.zwave_props` property:
@@ -110,7 +116,7 @@ V2 is a significant refactoring and cleanup of the original PyISY code, with the
     + `fade_stop`
     + `fast_on`
     + `fast_off`
-- In addition to the `node.parent_node` which returns a `Node` object if a node has a primary/parent node other than itself, there is now a `node.primary_node` property, which just returns the address of the primary node. If the device/group *is* the primary node, this is the same as the address (this is the `pnode` tag from `/rest/nodes`). 
+- In addition to the `node.parent_node` which returns a `Node` object if a node has a primary/parent node other than itself, there is now a `node.primary_node` property, which just returns the address of the primary node. If the device/group *is* the primary node, this is the same as the address (this is the `pnode` tag from `/rest/nodes`).
 - Expose the ISY Query Function (`/rest/query`) as `isy.query()`
 
 #### Fixes:

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -28,6 +28,8 @@ ES_CONNECTED = "connected"
 ES_DISCONNECTED = "disconnected"
 ES_START_UPDATES = "start_updates"
 ES_STOP_UPDATES = "stop_updates"
+ES_INITIALIZING = "stream_initializing"
+ES_LOADED = "stream_loaded"
 
 ISY_VALUE_UNKNOWN = -1 * float("inf")
 
@@ -114,6 +116,7 @@ PROTO_ZWAVE = "zwave"
 
 PROP_BATTERY_LEVEL = "BATLVL"
 PROP_BUSY = "BUSY"
+PROP_COMMS_ERROR = "ERR"
 PROP_ENERGY_MODE = "CLIEMD"
 PROP_HEAT_COOL_STATE = "CLIHCS"
 PROP_HUMIDITY = "CLIHUM"
@@ -203,7 +206,7 @@ COMMAND_FRIENDLY_NAME = {
     "DON5": "on_5x_key_presses",
     "ELECCON": "electrical_conductivity",
     "ELECRES": "electrical_resistivity",
-    "ERR": "device_communication_errors",
+    PROP_COMMS_ERROR: "device_communication_errors",
     "GPV": "general_purpose",
     "GV0": "custom_control_0",
     "GV1": "custom_control_1",
@@ -808,3 +811,40 @@ NODE_CATEGORIES = {
     "127": "virtual",
     "254": "unknown",
 }
+
+# Node Change Actions
+NC_NODE_RENAMED = "NN"
+NC_NODE_REMOVED = "NR"
+NC_NODE_MOVED = "MV"
+NC_NODE_REMOVE_FROM_GROUP = "RG"
+NC_NODE_ENABLED = "RG"
+NC_PARENT_CHANGED = "PC"
+NC_GROUP_RENAMED = "GN"
+NC_GROUP_REMOVED = "GR"
+NC_GROUP_ADDED = "GD"
+NC_FOLDER_RENAMED = "FN"
+NC_FOLDER_REMOVED = "FR"
+NC_FOLDER_ADDED = "FD"
+NC_NODE_ERROR = "NE"
+NC_CLEAR_ERROR = "CE"
+NC_NET_RENAMED = "WR"
+NC_NODE_REVISED = "RV"
+
+NODE_CHANGED_ACTIONS = [
+    NC_NODE_RENAMED,
+    NC_NODE_REMOVED,
+    NC_NODE_MOVED,
+    NC_NODE_REMOVE_FROM_GROUP,
+    NC_NODE_ENABLED,
+    NC_PARENT_CHANGED,
+    NC_GROUP_RENAMED,
+    NC_GROUP_REMOVED,
+    NC_GROUP_ADDED,
+    NC_FOLDER_RENAMED,
+    NC_FOLDER_REMOVED,
+    NC_FOLDER_ADDED,
+    NC_NODE_ERROR,
+    NC_CLEAR_ERROR,
+    NC_NET_RENAMED,
+    NC_NODE_REVISED,
+]

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -23,6 +23,12 @@ RECONNECT_DELAY = 60
 SOCKET_BUFFER_SIZE = 4096
 THREAD_SLEEP_TIME = 30.0
 
+ES_LOST_STREAM_CONNECTION = "lost_stream_connection"
+ES_CONNECTED = "connected"
+ES_DISCONNECTED = "disconnected"
+ES_START_UPDATES = "start_updates"
+ES_STOP_UPDATES = "stop_updates"
+
 ISY_VALUE_UNKNOWN = -1 * float("inf")
 
 XML_ERRORS = (AttributeError, KeyError, ValueError, TypeError, IndexError, ExpatError)

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -30,6 +30,8 @@ ES_START_UPDATES = "start_updates"
 ES_STOP_UPDATES = "stop_updates"
 ES_INITIALIZING = "stream_initializing"
 ES_LOADED = "stream_loaded"
+ES_RECONNECT_FAILED = "reconnect_failed"
+ES_RECONNECTING = "reconnecting"
 
 ISY_VALUE_UNKNOWN = -1 * float("inf")
 

--- a/pyisy/events.py
+++ b/pyisy/events.py
@@ -16,6 +16,8 @@ from .constants import (
     ATTR_VAR,
     ES_CONNECTED,
     ES_DISCONNECTED,
+    ES_INITIALIZING,
+    ES_LOADED,
     ES_LOST_STREAM_CONNECTION,
     POLL_TIME,
     PROP_STATUS,
@@ -40,6 +42,7 @@ class EventStream:
         self._connected = False
         self._lasthb = None
         self._hbwait = 0
+        self._loaded = None
         self._on_lost_function = on_lost_func
         self.cert = None
         self.data = connection_info
@@ -86,6 +89,12 @@ class EventStream:
         if not cntrl:
             return
         if cntrl == "_0":  # ISY HEARTBEAT
+            if self._loaded is None:
+                self._loaded = ES_INITIALIZING
+                self.isy.connection_events.notify(ES_INITIALIZING)
+            elif self._loaded == ES_INITIALIZING:
+                self._loaded = ES_LOADED
+                self.isy.connection_events.notify(ES_LOADED)
             self._lasthb = datetime.datetime.now()
             self._hbwait = int(value_from_xml(xmldoc, ATTR_ACTION))
             self.isy.log.debug("ISY HEARTBEAT: %s", self._lasthb.isoformat())
@@ -103,6 +112,8 @@ class EventStream:
             else:  # SOMETHING HAPPENED WITH A PROGRAM FOLDER
                 # but they ISY didn't tell us what, so...
                 self.isy.programs.update()
+        elif cntrl == "_3":  # Node Changed/Updated
+            self.isy.nodes.node_changed_received(xmldoc)
 
     def update_received(self, xmldoc):
         """Set the socket ID."""

--- a/pyisy/isy.py
+++ b/pyisy/isy.py
@@ -7,6 +7,8 @@ from .configuration import Configuration
 from .connection import Connection
 from .constants import (
     CMD_X10,
+    ES_RECONNECT_FAILED,
+    ES_RECONNECTING,
     ES_START_UPDATES,
     ES_STOP_UPDATES,
     URL_QUERY,
@@ -157,13 +159,13 @@ class ISY:
                 self, self.conn.connection_info, self._on_lost_event_stream
             )
             self._events.running = True
-            self.connection_events.notify("reconnecting")
+            self.connection_events.notify(ES_RECONNECTING)
 
         if not self.auto_update:
             del self._events
             self._events = None
             self.log.warning("PyISY could not reconnect to the event stream.")
-            self.connection_events.notify("reconnect_failed")
+            self.connection_events.notify(ES_RECONNECT_FAILED)
         else:
             self.log.warning("PyISY reconnected to the event stream.")
 


### PR DESCRIPTION
Add connection events for the Event Stream to allow subscription and callbacks. Attach a callback with `isy.connection_events(callback)` and receive a string with the event detail. See `constants.py` for events starting with prefix `ES_`.

This will allow detection and response in a subscriber to the different events, rather than just relying on the logs only.
