### PR TITLE
Add Devcontainer, Update Requirements, Use PyUpgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspaces
+
+# Install Python dependencies from requirements
+COPY requirements.txt requirements-dev.txt ./
+RUN pip3 install -r requirements.txt \
+    && pip3 install -r requirements-dev.txt \
+    && rm -f requirements.txt requirements-dev.txt
+
+ENV PATH=/root/.local/bin:${PATH}
+
+# Set the default shell to bash instead of sh
+ENV SHELL /bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "PyISY Devcontainer",
+  "context": "..",
+  "dockerFile": "Dockerfile",
+  "postCreateCommand": ".devcontainer/postCreate.sh",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "extensions": [
+    "ms-python.python",
+    "visualstudioexptteam.vscodeintellicode",
+    "esbenp.prettier-vscode"
+  ],
+  "settings": {
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.formatting.provider": "black",
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
+    "files.trimTrailingWhitespace": true,
+    "terminal.integrated.shell.linux": "/bin/bash"
+  }
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd /workspaces/PyISY
+
+# Setup the test_scripts folder as copy of the examples.
+mkdir test_scripts
+cp -r examples/* test_scripts/
+
+# Install the editable local package
+pip3 install -e .
+
+# Install pre-commit requirements
+pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ lib/
 lib64/
 parts/
 sdist/
+test_scripts/
 var/
 *.egg-info/
 .installed.cfg
@@ -61,6 +62,3 @@ docs/_build/
 # PyBuilder
 target/
 .AppleDouble
-
-# VSCode Configs
-.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: [--py37-plus]
   - hooks:
       - args: [--safe, --quiet]
-        files: ^((pyisy)/.+)?[^/]+\.py$
+        files: ^((pyisy|examples)/.+)?[^/]+\.py$
         id: black
     repo: https://github.com/psf/black
     rev: 19.10b0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 ---
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.3.0
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
   - hooks:
       - args: [--safe, --quiet]
         files: ^((pyisy)/.+)?[^/]+\.py$
@@ -7,8 +12,12 @@ repos:
     repo: https://github.com/psf/black
     rev: 19.10b0
   - hooks:
-      - args: ['--ignore-words-list=pyisy,hass,isy,nid,dof,dfof,don,dfon,tim',
-               '--skip="./.*,*.json"', --quiet-level=2]
+      - args:
+          [
+            "--ignore-words-list=pyisy,hass,isy,nid,dof,dfof,don,dfon,tim",
+            '--skip="./.*,*.json"',
+            --quiet-level=2,
+          ]
         exclude_types: [json]
         id: codespell
     repo: https://github.com/codespell-project/codespell
@@ -18,8 +27,8 @@ repos:
         files: ^(pyisy)/.+\.py$
         id: flake8
     repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.1
   - hooks:
-      - {id: isort}
+      - { id: isort }
     repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "ms-python.python"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "python.linting.pylintEnabled": false,
+  "python.linting.enabled": true,
+  "python.formatting.provider": "black",
+  "editor.formatOnPaste": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
+  "files.trimTrailingWhitespace": true,
+  "terminal.integrated.shell.linux": "/bin/bash",
+  "python.linting.flake8Enabled": true
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library allows for easy interaction with ISY nodes, programs, variables, an
 assigned as handlers when ISY parameters are changed. ISY parameters can be
 monitored automatically as changes are reported from the device.
 
-**NOTE:** Significant changes have been made in V2, please refer to the [CHANGELOG](CHANGELOG.md) for details. It is recommended you do not update  to the latest version without testing for any unknown breaking changes or impacts to your dependent code.
+**NOTE:** Significant changes have been made in V2, please refer to the [CHANGELOG](CHANGELOG.md) for details. It is recommended you do not update to the latest version without testing for any unknown breaking changes or impacts to your dependent code.
 
 ### Examples
 
@@ -14,9 +14,9 @@ See the [examples](examples/) folder for connection examples.
 
 ### Development Team
 
-* Greg Laabs ([@OverloadUT]) - Maintainer
-* Ryan Kraus ([@rmkraus]) - Creator
-* Tim Bond ([@shbatm]) - Version 2 Contributor
+- Greg Laabs ([@overloadut]) - Maintainer
+- Ryan Kraus ([@rmkraus]) - Creator
+- Tim Bond ([@shbatm]) - Version 2 Contributor
 
 ### Contributing
 
@@ -32,6 +32,17 @@ pip install pre-commit
 pre-commit install
 ```
 
-[@OverloadUT]: https://github.com/overloadut
+A [VSCode DevContainer](https://code.visualstudio.com/docs/remote/containers#_getting-started) is also available to provide a consistent development environment.
+
+Assuming you have the pre-requisites installed from the link above (VSCode, Docker, & Remote-Containers Extension), to get started:
+
+1. Fork the repository.
+2. Clone the repository to your computer.
+3. Open the repository using Visual Studio code.
+4. When you open this repository with Visual Studio code you are asked to "Reopen in Container", this will start the build of the container.
+   - If you don't see this notification, open the command palette and select Remote-Containers: Reopen Folder in Container.
+5. Once started, you will also have a `test_scripts/` folder with a copy of the example scripts to run in the container which won't be committed to the repo, so you can update them with your connection details and test directly on your ISY.
+
+[@overloadut]: https://github.com/overloadut
 [@rmkraus]: https://github.com/rmkraus
 [@shbatm]: https://github.com/shbatm

--- a/examples/connection_test.py
+++ b/examples/connection_test.py
@@ -24,6 +24,7 @@ LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def main(arguments):
     """Execute primary loop."""
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FORMAT, level=LOG_LEVEL)

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -252,7 +252,7 @@ class TLSHttpAdapter(HTTPAdapter):
             self.tls = ssl.PROTOCOL_TLSv1_1
         elif tls_ver == 1.2:
             self.tls = ssl.PROTOCOL_TLSv1_2
-        super(TLSHttpAdapter, self).__init__()
+        super().__init__()
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         """Initialize the Pool Manager."""

--- a/pyisy/eventreader.py
+++ b/pyisy/eventreader.py
@@ -1,7 +1,6 @@
 """ISY Event Reader."""
 import errno
 import select
-import socket
 import ssl
 
 from .constants import SOCKET_BUFFER_SIZE
@@ -81,7 +80,7 @@ class ISYEventReader:
                 self._event_buffer += new_data
         except ssl.SSLWantReadError:
             pass
-        except socket.error as ex:
+        except OSError as ex:
             if ex.errno != errno.EWOULDBLOCK:
                 raise
 

--- a/pyisy/events.py
+++ b/pyisy/events.py
@@ -247,7 +247,7 @@ class EventStream:
                 )
                 self._lost_connection()
                 return
-            except socket.error as ex:
+            except OSError as ex:
                 self.isy.log.warning(
                     "PyISY encountered a socket error while reading the event stream: %s.",
                     ex,

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -339,7 +339,8 @@ class Node(NodeBase):
         if not self.is_thermostat:
             self.isy.log.warning(
                 "Failed to set %s setpoint on %s, it is not a thermostat node.",
-                setpoint_name, self.address,
+                setpoint_name,
+                self.address,
             )
             return
         # ISY wants 2 times the temperature for Insteon in order to not lose precision

--- a/pyisy/programs/program.py
+++ b/pyisy/programs/program.py
@@ -44,7 +44,7 @@ class Program(Folder):
         prunning,
     ):
         """Initialize a Program class."""
-        super(Program, self).__init__(programs, address, pname, pstatus, plastup)
+        super().__init__(programs, address, pname, pstatus, plastup)
         self._enabled = penabled
         self._last_finished = plastfin
         self._last_run = plastrun

--- a/pyisy/variables/variable.py
+++ b/pyisy/variables/variable.py
@@ -36,7 +36,7 @@ class Variable:
 
     def __init__(self, variables, vid, vtype, vname, init, status, ts):
         """Initialize a Variable class."""
-        super(Variable, self).__init__()
+        super().__init__()
         self._id = vid
         self._init = init
         self._last_edited = ts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,10 @@
-pre-commit
+pylint==2.4.4
+pylint-strict-informational==0.1
+black==19.10b0
+codespell==1.16.0
+flake8-docstrings==1.5.0
+flake8==3.8.1
+isort==4.3.21
+pydocstyle==5.0.2
+pyupgrade==2.3.0
+pre-commit>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.22
+python-dateutil>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     include_package_data=True,
     platforms="any",
     setup_requires=["setuptools-git-version"],
-    install_requires=["requests"],
+    install_requires=["requests", "python-dateutil"],
     keywords=["home automation", "isy", "isy994", "isy-994", "UDI"],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
- Add a VSCode Devcontainer based on Python 3.8
- Update the package requirements to explicitly include `dateutil` and the dev requirements for `pre-commit`
- Add `pyupgrade` hook to `pre-commit` and run it on the whole repo.

Tested on VSCode, Docker on Windows 10.

Tag @OverloadUT 