### PR TITLE
Logging cleanup and consolidation

### DIFF
--- a/examples/connection_test.py
+++ b/examples/connection_test.py
@@ -39,7 +39,6 @@ def main(arguments):
             password=PASSWORD,
             use_https=USE_HTTPS,
             tls_ver=TLS_VER,
-            log=_LOGGER,
             webroot=WEBROOT,
         )
     except ValueError as err:
@@ -60,7 +59,6 @@ def main(arguments):
         password=PASSWORD,
         use_https=USE_HTTPS,
         tls_ver=TLS_VER,
-        log=_LOGGER,
         webroot=WEBROOT,
     )
 

--- a/examples/connection_test.py
+++ b/examples/connection_test.py
@@ -28,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 def main(arguments):
     """Execute primary loop."""
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FORMAT, level=LOG_LEVEL)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     # Test the connection to ISY controller.
     try:

--- a/pyisy/clock.py
+++ b/pyisy/clock.py
@@ -3,6 +3,7 @@ from time import sleep
 from xml.dom import minidom
 
 from .constants import (
+    _LOGGER,
     EMPTY_TIME,
     TAG_DST,
     TAG_LATITUDE,
@@ -81,7 +82,7 @@ class Clock:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: Clock", XML_PARSE_ERROR)
+            _LOGGER.error("%s: Clock", XML_PARSE_ERROR)
         else:
             tz_offset_sec = int(value_from_xml(xmldoc, TAG_TZ_OFFSET))
             self._tz_offset = tz_offset_sec / 3600
@@ -93,7 +94,7 @@ class Clock:
             self._sunrise = ntp_to_system_time(int(value_from_xml(xmldoc, TAG_SUNRISE)))
             self._sunset = ntp_to_system_time(int(value_from_xml(xmldoc, TAG_SUNSET)))
 
-            self.isy.log.info("ISY Loaded Clock Information")
+            _LOGGER.info("ISY Loaded Clock Information")
 
     def update(self, wait_time=0):
         """

--- a/pyisy/configuration.py
+++ b/pyisy/configuration.py
@@ -2,6 +2,7 @@
 from xml.dom import minidom
 
 from .constants import (
+    _LOGGER,
     ATTR_DESC,
     ATTR_ID,
     TAG_DESC,
@@ -62,20 +63,15 @@ class Configuration(dict):
         # configuration['21040']
         True
 
-    ATTRIBUTES:
-        log: The logger to use.
-
     """
 
-    def __init__(self, log, xml=None):
+    def __init__(self, xml=None):
         """
         Initialize configuration class.
 
-        log: logger to use
         xml: String of xml data containing the configuration data
         """
         super().__init__()
-        self.log = log
 
         if xml is not None:
             self.parse(xml)
@@ -104,4 +100,4 @@ class Configuration(dict):
             self[idnum] = installed
             self[desc] = self[idnum]
 
-        self.log.info("ISY Loaded Configuration")
+        _LOGGER.info("ISY Loaded Configuration")

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -1,9 +1,15 @@
 """Constants for the PyISY Module."""
 import datetime
+import logging
 from xml.parsers.expat import ExpatError
 
+_LOGGER = logging.getLogger(__package__)
+LOG_LEVEL = logging.DEBUG
+LOG_VERBOSE = 5
+LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
 UPDATE_INTERVAL = 0.5
-VERBOSE = 5  # Verbose Logging Level
 
 
 # Time Constants / Strings

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -1,6 +1,5 @@
 """Helper functions for the PyISY Module."""
 import datetime
-from logging import Handler
 import time
 
 from .constants import (
@@ -261,14 +260,6 @@ class NodeProperty(dict):
     def __setattr__(self, name, value):
         """Allow setting of properties."""
         self[name] = value
-
-
-class NullHandler(Handler):
-    """NullHandler Logging Class Override."""
-
-    def emit(self, record):
-        """Override the Emit function."""
-        pass
 
 
 class ZWaveProperties(dict):

--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -3,6 +3,7 @@ from time import sleep
 from xml.dom import minidom
 
 from .constants import (
+    _LOGGER,
     ATTR_ID,
     TAG_NAME,
     TAG_NET_RULE,
@@ -65,7 +66,7 @@ class NetworkResources:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: NetworkResources", XML_PARSE_ERROR)
+            _LOGGER.error("%s: NetworkResources", XML_PARSE_ERROR)
         else:
             features = xmldoc.getElementsByTagName(TAG_NET_RULE)
             for feature in features:
@@ -77,7 +78,7 @@ class NetworkResources:
                     self.nnames.append(nname)
                     self.nobjs.append(nobj)
 
-            self.isy.log.info("ISY Loaded Network Resources Commands")
+            _LOGGER.info("ISY Loaded Network Resources Commands")
 
     def update(self, wait_time=0):
         """
@@ -175,8 +176,6 @@ class NetworkCommand:
         req_url = self.isy.conn.compile_url([URL_NETWORK, URL_RESOURCES, str(self._id)])
 
         if not self.isy.conn.request(req_url, ok404=True):
-            self.isy.log.warning(
-                "ISY could not run networking command: %s", str(self._id)
-            )
+            _LOGGER.warning("ISY could not run networking command: %s", str(self._id))
             return
-        self.isy.log.debug("ISY ran networking command: %s", str(self._id))
+        _LOGGER.debug("ISY ran networking command: %s", str(self._id))

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -3,6 +3,7 @@ from time import sleep
 from xml.dom import minidom
 
 from ..constants import (
+    _LOGGER,
     ATTR_ACTION,
     ATTR_CONTROL,
     ATTR_FLAG,
@@ -194,7 +195,7 @@ class Nodes:
 
         node = self.get_by_id(address)
         if not node:
-            self.isy.log.debug(
+            _LOGGER.debug(
                 "Received a node update for node %s but could not find a record of this "
                 "node. Please try restarting the module if the problem persists, this "
                 "may be due to a new node being added to the ISY since last restart.",
@@ -211,7 +212,7 @@ class Nodes:
         node.update_state(
             NodeProperty(PROP_STATUS, value, prec, uom, formatted, address)
         )
-        self.isy.log.debug("ISY Updated Node: " + address)
+        _LOGGER.debug("ISY Updated Node: " + address)
 
     def control_message_received(self, xmldoc):
         """
@@ -227,7 +228,7 @@ class Nodes:
 
         node = self.get_by_id(address)
         if not node:
-            self.isy.log.debug(
+            _LOGGER.debug(
                 "Received a node update for node %s but could not find a record of this "
                 "node. Please try restarting the module if the problem persists, this "
                 "may be due to a new node being added to the ISY since last restart.",
@@ -257,7 +258,7 @@ class Nodes:
         elif cntrl not in EVENT_PROPS_IGNORED:
             node.update_property(node_property)
         node.control_events.notify(node_property)
-        self.isy.log.debug("ISY Node Control Event: %s", node_property)
+        _LOGGER.debug("ISY Node Control Event: %s", node_property)
 
     def node_changed_received(self, xmldoc):
         """Handle Node Change/Update events from an event stream message."""
@@ -266,7 +267,7 @@ class Nodes:
             return
         node = value_from_xml(xmldoc, TAG_NODE)
         if action == NC_NODE_ERROR:
-            self.isy.log.warning("ISY Could not communicate with device: %s", node)
+            _LOGGER.warning("ISY Could not communicate with device: %s", node)
         # FUTURE: Handle additional node change actions to force updates.
 
     def parse(self, xml):
@@ -278,7 +279,7 @@ class Nodes:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: Nodes", XML_PARSE_ERROR)
+            _LOGGER.error("%s: Nodes", XML_PARSE_ERROR)
             return False
 
         # get nodes
@@ -353,9 +354,7 @@ class Nodes:
                     # the ISY MAC address in newer versions of
                     # ISY firmwares > 5.0.6+ ..
                     if int(flag) & 0x08:
-                        self.isy.log.debug(
-                            "Skipping root group flag=%s %s", flag, address
-                        )
+                        _LOGGER.debug("Skipping root group flag=%s %s", flag, address)
                         continue
                     mems = feature.getElementsByTagName(TAG_LINK)
                     # Build list of members
@@ -380,7 +379,7 @@ class Nodes:
                         ),
                         ntype,
                     )
-            self.isy.log.debug("ISY Loaded %s", ntype)
+            _LOGGER.debug("ISY Loaded %s", ntype)
 
     def update(self, wait_time=0):
         """
@@ -395,13 +394,13 @@ class Nodes:
         xml = self.isy.conn.get_status()
 
         if xml is None:
-            self.isy.log.warning("ISY Failed to update nodes.")
+            _LOGGER.warning("ISY Failed to update nodes.")
             return
 
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: Nodes", XML_PARSE_ERROR)
+            _LOGGER.error("%s: Nodes", XML_PARSE_ERROR)
             return False
 
         for feature in xmldoc.getElementsByTagName(TAG_NODE):
@@ -411,7 +410,7 @@ class Nodes:
                 self.get_by_id(address).update(xmldoc=feature)
                 continue
 
-        self.isy.log.info("ISY Updated Node Statuses.")
+        _LOGGER.info("ISY Updated Node Statuses.")
 
     def update_nodes(self, wait_time=0):
         """
@@ -425,7 +424,7 @@ class Nodes:
             sleep(wait_time)
         xml = self.isy.conn.get_nodes()
         if xml is None:
-            self.isy.log.warning("ISY Failed to update nodes.")
+            _LOGGER.warning("ISY Failed to update nodes.")
             return
         self.parse(xml)
 

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -4,6 +4,7 @@ from time import sleep
 from xml.dom import minidom
 
 from ..constants import (
+    _LOGGER,
     CLIMATE_SETPOINT_MIN_GAP,
     CMD_CLIMATE_FAN_SETTING,
     CMD_CLIMATE_MODE,
@@ -200,28 +201,28 @@ class Node(NodeBase):
             try:
                 xmldoc = minidom.parseString(xml)
             except XML_ERRORS:
-                self.isy.log.error("%s: Nodes", XML_PARSE_ERROR)
+                _LOGGER.error("%s: Nodes", XML_PARSE_ERROR)
                 return
         elif hint is not None:
             # assume value was set correctly, auto update will correct errors
             self.status = hint
-            self.isy.log.debug("ISY updated node: %s", self._id)
+            _LOGGER.debug("ISY updated node: %s", self._id)
             return
 
         if xmldoc is None:
-            self.isy.log.warning("ISY could not update node: %s", self._id)
+            _LOGGER.warning("ISY could not update node: %s", self._id)
             return
 
         self._last_update = now()
         state, aux_props = parse_xml_properties(xmldoc)
         self._aux_properties.update(aux_props)
         self.update_state(state)
-        self.isy.log.debug("ISY updated node: %s", self._id)
+        _LOGGER.debug("ISY updated node: %s", self._id)
 
     def update_state(self, state):
         """Update the various state properties when received."""
         if not isinstance(state, NodeProperty):
-            self.isy.log.error("Could not update state values. Invalid type provided.")
+            _LOGGER.error("Could not update state values. Invalid type provided.")
             return
         changed = False
         self._last_update = now()
@@ -250,7 +251,7 @@ class Node(NodeBase):
     def get_command_value(self, uom, cmd):
         """Check against the list of UOM States if this is a valid command."""
         if cmd not in UOM_TO_STATES[uom].values():
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Failed to call %s on %s, invalid command.", cmd, self.address
             )
             return None
@@ -286,25 +287,21 @@ class Node(NodeBase):
     def secure_lock(self):
         """Send a command to securely lock a lock device."""
         if not self.is_lock:
-            self.isy.log.warning(
-                "Failed to lock %s, it is not a lock node.", self.address
-            )
+            _LOGGER.warning("Failed to lock %s, it is not a lock node.", self.address)
             return
         return self.send_cmd(CMD_SECURE, "1")
 
     def secure_unlock(self):
         """Send a command to securely lock a lock device."""
         if not self.is_lock:
-            self.isy.log.warning(
-                "Failed to unlock %s, it is not a lock node.", self.address
-            )
+            _LOGGER.warning("Failed to unlock %s, it is not a lock node.", self.address)
             return
         return self.send_cmd(CMD_SECURE, "0")
 
     def set_climate_mode(self, cmd):
         """Send a command to the device to set the climate mode."""
         if not self.is_thermostat:
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Failed to set setpoint on %s, it is not a thermostat node.",
                 self.address,
             )
@@ -316,7 +313,7 @@ class Node(NodeBase):
     def set_climate_setpoint(self, val):
         """Send a command to the device to set the system setpoints."""
         if not self.is_thermostat:
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Failed to set setpoint on %s, it is not a thermostat node.",
                 self.address,
             )
@@ -337,7 +334,7 @@ class Node(NodeBase):
     def _set_climate_setpoint(self, val, setpoint_name, setpoint_prop):
         """Send a command to the device to set the system heat setpoint."""
         if not self.is_thermostat:
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Failed to set %s setpoint on %s, it is not a thermostat node.",
                 setpoint_name,
                 self.address,
@@ -360,7 +357,7 @@ class Node(NodeBase):
     def set_on_level(self, val):
         """Set the ON Level for a device."""
         if not val or isnan(val) or int(val) not in range(256):
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Invalid value for On Level for %s. Valid values are 0-255.", self._id
             )
             return False
@@ -369,7 +366,7 @@ class Node(NodeBase):
     def set_ramp_rate(self, val):
         """Set the Ramp Rate for a device."""
         if not val or isnan(val) or int(val) not in range(32):
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "Invalid value for Ramp Rate for %s. "
                 "Valid values are 0-31. See 'INSTEON_RAMP_RATES' in constants.py for values.",
                 self._id,
@@ -379,14 +376,14 @@ class Node(NodeBase):
 
     def start_manual_dimming(self):
         """Begin manually dimming a device."""
-        self.isy.log.warning(
+        _LOGGER.warning(
             f"'{CMD_MANUAL_DIM_BEGIN}' is depreciated. Use Fade Commands instead."
         )
         return self.send_cmd(CMD_MANUAL_DIM_BEGIN)
 
     def stop_manual_dimming(self):
         """Stop manually dimming  a device."""
-        self.isy.log.warning(
+        _LOGGER.warning(
             f"'{CMD_MANUAL_DIM_STOP}' is depreciated. Use Fade Commands instead."
         )
         return self.send_cmd(CMD_MANUAL_DIM_STOP)

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -2,6 +2,7 @@
 from xml.dom import minidom
 
 from ..constants import (
+    _LOGGER,
     ATTR_LAST_CHANGED,
     ATTR_LAST_UPDATE,
     ATTR_STATUS,
@@ -178,7 +179,7 @@ class NodeBase:
             try:
                 notesdom = minidom.parseString(notes_xml)
             except XML_ERRORS:
-                self.isy.log.error("%s: Node Notes %s", XML_PARSE_ERROR, notes_xml)
+                _LOGGER.error("%s: Node Notes %s", XML_PARSE_ERROR, notes_xml)
             else:
                 spoken = value_from_xml(notesdom, TAG_SPOKEN)
                 location = value_from_xml(notesdom, TAG_LOCATION)
@@ -198,9 +199,7 @@ class NodeBase:
     def update_property(self, prop):
         """Update an aux property for the node when received."""
         if not isinstance(prop, NodeProperty):
-            self.isy.log.error(
-                "Could not update property value. Invalid type provided."
-            )
+            _LOGGER.error("Could not update property value. Invalid type provided.")
             return
         self.update_last_update()
 
@@ -238,13 +237,13 @@ class NodeBase:
             req.append(_uom)
         req_url = self.isy.conn.compile_url(req, query)
         if not self.isy.conn.request(req_url):
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "ISY could not send %s command to %s.",
                 COMMAND_FRIENDLY_NAME.get(cmd),
                 self._id,
             )
             return False
-        self.isy.log.debug(
+        _LOGGER.debug(
             "ISY command %s sent to %s.", COMMAND_FRIENDLY_NAME.get(cmd), self._id
         )
 
@@ -281,7 +280,7 @@ class NodeBase:
         if not self.isy.conn.request(
             self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_DISABLE])
         ):
-            self.isy.log.warning("ISY could not %s %s.", CMD_DISABLE, self._id)
+            _LOGGER.warning("ISY could not %s %s.", CMD_DISABLE, self._id)
             return False
         return True
 
@@ -290,7 +289,7 @@ class NodeBase:
         if not self.isy.conn.request(
             self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_ENABLE])
         ):
-            self.isy.log.warning("ISY could not %s %s.", CMD_ENABLE, self._id)
+            _LOGGER.warning("ISY could not %s %s.", CMD_ENABLE, self._id)
             return False
         return True
 

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -5,6 +5,7 @@ from xml.dom import minidom
 from dateutil import parser
 
 from ..constants import (
+    _LOGGER,
     ATTR_ID,
     ATTR_PARENT,
     ATTR_STATUS,
@@ -181,7 +182,7 @@ class Programs:
                 # Status didn't change, but something did, so fire the event.
                 pobj.status_events.notify(new_status)
 
-        self.isy.log.debug("ISY Updated Program: " + address)
+        _LOGGER.debug("ISY Updated Program: " + address)
 
     def parse(self, xml):
         """
@@ -192,7 +193,7 @@ class Programs:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: Programs", XML_PARSE_ERROR)
+            _LOGGER.error("%s: Programs", XML_PARSE_ERROR)
         else:
             plastup = now()
 
@@ -255,7 +256,7 @@ class Programs:
                     pobj = self.get_by_id(address).leaf
                     pobj.update(data=data)
 
-            self.isy.log.info("ISY Loaded/Updated Programs")
+            _LOGGER.info("ISY Loaded/Updated Programs")
 
     def update(self, wait_time=UPDATE_INTERVAL, address=None):
         """
@@ -270,7 +271,7 @@ class Programs:
         if xml is not None:
             self.parse(xml)
         else:
-            self.isy.log.warning("ISY Failed to update programs.")
+            _LOGGER.warning("ISY Failed to update programs.")
 
     def insert(self, address, pname, pparent, pobj, ptype):
         """

--- a/pyisy/programs/folder.py
+++ b/pyisy/programs/folder.py
@@ -1,5 +1,6 @@
 """ISY Program Folders."""
 from ..constants import (
+    _LOGGER,
     ATTR_LAST_CHANGED,
     ATTR_LAST_UPDATE,
     ATTR_STATUS,
@@ -134,11 +135,9 @@ class Folder:
         req_url = self.isy.conn.compile_url([URL_PROGRAMS, str(self._id), command])
         result = self.isy.conn.request(req_url)
         if not result:
-            self.isy.log.warning(
-                'ISY could not call "%s" on program: %s', command, self._id
-            )
+            _LOGGER.warning('ISY could not call "%s" on program: %s', command, self._id)
             return False
-        self.isy.log.debug('ISY ran "%s" on program: %s', command, self._id)
+        _LOGGER.debug('ISY ran "%s" on program: %s', command, self._id)
         if not self.isy.auto_update:
             self.update()
         return True

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -5,6 +5,7 @@ from xml.dom import minidom
 from dateutil import parser
 
 from ..constants import (
+    _LOGGER,
     ATTR_ID,
     ATTR_INIT,
     ATTR_TS,
@@ -99,7 +100,7 @@ class Variables:
             try:
                 xmldoc = minidom.parseString(xmls[ind])
             except XML_ERRORS:
-                self.isy.log.error("%s: Type %s Variables", XML_PARSE_ERROR, ind + 1)
+                _LOGGER.error("%s: Type %s Variables", XML_PARSE_ERROR, ind + 1)
                 continue
 
             features = xmldoc.getElementsByTagName(TAG_VARIABLE)
@@ -112,7 +113,7 @@ class Variables:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            self.isy.log.error("%s: Variables", XML_PARSE_ERROR)
+            _LOGGER.error("%s: Variables", XML_PARSE_ERROR)
             return
 
         features = xmldoc.getElementsByTagName(ATTR_VAR)
@@ -135,7 +136,7 @@ class Variables:
                 vobj.status = val
                 vobj.last_edited = t_s
 
-        self.isy.log.info("ISY Loaded Variables")
+        _LOGGER.info("ISY Loaded Variables")
 
     def update(self, wait_time=0):
         """
@@ -148,7 +149,7 @@ class Variables:
         if xml is not None:
             self.parse(xml)
         else:
-            self.isy.log.warning("ISY Failed to update variables.")
+            _LOGGER.warning("ISY Failed to update variables.")
 
     def update_received(self, xmldoc):
         """Process an update received from the event stream."""
@@ -167,7 +168,7 @@ class Variables:
             vobj.status = int(value_from_xml(xmldoc, ATTR_VAL))
             vobj.last_edited = parser.parse(value_from_xml(xmldoc, ATTR_TS))
 
-        self.isy.log.debug("ISY Updated Variable: %s.%s", str(vtype), str(vid))
+        _LOGGER.debug("ISY Updated Variable: %s.%s", str(vtype), str(vid))
 
     def __getitem__(self, val):
         """

--- a/pyisy/variables/variable.py
+++ b/pyisy/variables/variable.py
@@ -1,5 +1,6 @@
 """Manage variables from the ISY."""
 from ..constants import (
+    _LOGGER,
     ATTR_INIT,
     ATTR_LAST_CHANGED,
     ATTR_LAST_UPDATE,
@@ -183,14 +184,14 @@ class Variable:
             ]
         )
         if not self.isy.conn.request(req_url):
-            self.isy.log.warning(
+            _LOGGER.warning(
                 "ISY could not set variable%s: %s.%s",
                 " init value" if init else "",
                 str(self._type),
                 str(self._id),
             )
             return
-        self.isy.log.debug(
+        _LOGGER.debug(
             "ISY set variable%s: %s.%s",
             " init value" if init else "",
             str(self._type),


### PR DESCRIPTION
## Breaking Change

This removes the `log=` parameter when initializing new `Connection` and `ISY` class instances. Please update any loading functions you may use to remove this `log=` parameter.

## Details

General cleanup of all logging.

Removes reliance on `isy` parent objects to provide logger and uses a module-wide `_LOGGER`.  Everything will be logged under the `pyisy` namespace except Events. Events maintains a separate logger namespace to allow targeting in handlers of `pyisy.events`.