### PR TITLE
Guard against overwriting known attributes with blanks

### DIFF
--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -230,7 +230,7 @@ class Node(NodeBase):
             self._prec = state.prec
             changed = True
 
-        if state.uom != self._uom:
+        if state.uom != self._uom and state.uom != "":
             self._uom = state.uom
             changed = True
 
@@ -339,7 +339,8 @@ class Node(NodeBase):
         if not self.is_thermostat:
             self.isy.log.warning(
                 "Failed to set %s setpoint on %s, it is not a thermostat node.",
-                setpoint_name, self.address,
+                setpoint_name,
+                self.address,
             )
             return
         # ISY wants 2 times the temperature for Insteon in order to not lose precision

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -205,8 +205,12 @@ class NodeBase:
         self.update_last_update()
 
         aux_prop = self.aux_properties.get(prop.control)
-        if aux_prop and aux_prop == prop:
-            return
+        if aux_prop:
+            if prop.uom == "" and not aux_prop.uom == "":
+                # Guard against overwriting known UOM with blank UOM (ISYv4).
+                prop.uom = aux_prop.uom
+            if aux_prop == prop:
+                return
         self.aux_properties[prop.control] = prop
         self.update_last_changed()
         self.status_events.notify(self.status_feedback)


### PR DESCRIPTION
ISYv4 firmware sends blank UOMs in the event updates, which can cause issues if it overwrites a known, valid UOM.

This should resolve the issue home-assistant/core#37537 once a new package is published.
