### PR TITLE
Fix #109 - Update for events depreciation warning

### DIFF
--- a/pyisy/events.py
+++ b/pyisy/events.py
@@ -123,7 +123,7 @@ class EventStream:
     def running(self):
         """Return the running state of the thread."""
         try:
-            return self._thread.isAlive()
+            return self._thread.is_alive()
         except (AttributeError, RuntimeError, ThreadError):
             return False
 


### PR DESCRIPTION
Fixes #109 by resolving the depreciation warning isAlive() 

```
2020-06-22 15:15:51,271 Thread-2   py.warnings        WARNING  warnings:_showwarnmsg: /var/polyglot/.local/lib/python3.7/site-packages/pyisy/events.py:113: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead
```