### PR TITLE
Revise Node.dimmable property to exclude non-dimmable subnodes

### DIFF
--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -687,8 +687,16 @@ INSTEON_RAMP_RATES = {
 
 # Thermostat Types/Categories. 4.8 Trane, 5.3 venstar, 5.10 Insteon Wireless,
 #  5.11 Insteon, 5.17 Insteon (EU), 5.18 Insteon (Aus/NZ)
-THERMOSTAT_TYPES = ["4.8", "5.3", "5.10", "5.11", "5.17", "5.18"]
-THERMOSTAT_ZWAVE_CAT = ["140"]
+INSTEON_TYPE_THERMOSTAT = ["4.8", "5.3", "5.10", "5.11", "5.17", "5.18"]
+ZWAVE_CAT_THERMOSTAT = ["140"]
+
+# Other special categories or types
+INSTEON_TYPE_LOCK = ["4.64"]
+ZWAVE_CAT_LOCK = ["111"]
+
+INSTEON_TYPE_DIMMABLE = ["1."]
+INSTEON_SUBNODE_DIMMABLE = " 1"
+ZWAVE_CAT_DIMMABLE = ["109", "119", "186"]
 
 # Referenced from ISY-WSDK 4_fam.xml
 # Included for user translations in external modules.

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -11,22 +11,28 @@ from ..constants import (
     CMD_MANUAL_DIM_BEGIN,
     CMD_MANUAL_DIM_STOP,
     CMD_SECURE,
+    INSTEON_SUBNODE_DIMMABLE,
+    INSTEON_TYPE_DIMMABLE,
+    INSTEON_TYPE_LOCK,
+    INSTEON_TYPE_THERMOSTAT,
     METHOD_GET,
     PROP_ON_LEVEL,
     PROP_RAMP_RATE,
     PROP_SETPOINT_COOL,
     PROP_SETPOINT_HEAT,
     PROP_STATUS,
+    PROTO_INSTEON,
     PROTO_ZWAVE,
     TAG_GROUP,
-    THERMOSTAT_TYPES,
-    THERMOSTAT_ZWAVE_CAT,
     UOM_CLIMATE_MODES,
     UOM_FAN_MODES,
     UOM_TO_STATES,
     URL_NODES,
     XML_ERRORS,
     XML_PARSE_ERROR,
+    ZWAVE_CAT_DIMMABLE,
+    ZWAVE_CAT_LOCK,
+    ZWAVE_CAT_THERMOSTAT,
 )
 from ..helpers import EventEmitter, NodeProperty, now, parse_xml_properties
 from .nodebase import NodeBase
@@ -100,18 +106,10 @@ class Node(NodeBase):
         """
         Return the best guess if this is a dimmable node.
 
-        Check ISYv4 UOM, then Insteon and Z-Wave Types for dimmable types.
+        DEPRECIATED: USE is_dimmable INSTEAD. Will be removed in future release.
         """
-        dimmable = (
-            "%" in str(self._uom)
-            or (isinstance(self._type, str) and self._type.startswith("1."))
-            or (
-                self._protocol == PROTO_ZWAVE
-                and self._zwave_props is not None
-                and self._zwave_props.category in ["109", "119", "186"]
-            )
-        )
-        return dimmable
+        self.isy.log.info("Node.dimmable is depreciated. Use Node.is_dimmable instead.")
+        return self.is_dimmable
 
     @property
     def enabled(self):
@@ -124,21 +122,49 @@ class Node(NodeBase):
         return self._formatted
 
     @property
+    def is_dimmable(self):
+        """
+        Return the best guess if this is a dimmable node.
+
+        Check ISYv4 UOM, then Insteon and Z-Wave Types for dimmable types.
+        """
+        dimmable = (
+            "%" in str(self._uom)
+            or (
+                self._protocol == PROTO_INSTEON
+                and self.type
+                and any([self.type.startswith(t) for t in INSTEON_TYPE_DIMMABLE])
+                and self._id.endswith(INSTEON_SUBNODE_DIMMABLE)
+            )
+            or (
+                self._protocol == PROTO_ZWAVE
+                and self._zwave_props is not None
+                and self._zwave_props.category in ZWAVE_CAT_DIMMABLE
+            )
+        )
+        return dimmable
+
+    @property
     def is_lock(self):
         """Determine if this device is a door lock type."""
-        return (self.type and self.type.startswith("4.64")) or (
-            self.protocol == PROTO_ZWAVE and self.zwave_props.category == "111"
+        return (
+            self.type and any([self.type.startswith(t) for t in INSTEON_TYPE_LOCK])
+        ) or (
+            self.protocol == PROTO_ZWAVE
+            and self.zwave_props.category
+            and self.zwave_props.category in ZWAVE_CAT_LOCK
         )
 
     @property
     def is_thermostat(self):
         """Determine if this device is a thermostat/climate control device."""
         return (
-            self.type and any([self.type.startswith(t) for t in THERMOSTAT_TYPES])
+            self.type
+            and any([self.type.startswith(t) for t in INSTEON_TYPE_THERMOSTAT])
         ) or (
             self._protocol == PROTO_ZWAVE
             and self.zwave_props.category
-            and any(self.zwave_props.category in THERMOSTAT_ZWAVE_CAT)
+            and self.zwave_props.category in ZWAVE_CAT_THERMOSTAT
         )
 
     @property

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -108,7 +108,7 @@ class Node(NodeBase):
 
         DEPRECIATED: USE is_dimmable INSTEAD. Will be removed in future release.
         """
-        self.isy.log.info("Node.dimmable is depreciated. Use Node.is_dimmable instead.")
+        _LOGGER.info("Node.dimmable is depreciated. Use Node.is_dimmable instead.")
         return self.is_dimmable
 
     @property


### PR DESCRIPTION
## Breaking Change

- `Node.dimmable` has been depreciated in favor of `Node.is_dimmable` to make the naming more consistent with `is_lock` and `is_thermostat`. `Node.dimmable` will still work, however, plan for it to be removed in the future.
- `Node.is_dimmable` will only include the first subnode for Insteon devices in type 1. This should represent the main (load) button for KeypadLincs and the light for FanLincs, all other subnodes (KPL buttons and Fan Motor) are not dimmable (fixes #110)

## All Changes

- Revise `is_lock`, `is_thermostat`, and `is_lock` properties of the Node class to be more consistent.
- Use string literals for special Insteon types

## General Notes

- Using the `is_dimmable` property of a node is not considered reliable. As of Version 2, there is no truly reliable "sorting" of device types within the PyISY module itself, the module is non-discriminate when allowing command calls to the ISY. It is expected that the code using this module takes additional steps to ensure only valid commands are called on the various device types or risk them being ignored by the ISY. 
