### PR TITLE
Force UTF-8 decoding of responses and ignore errors

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -152,7 +152,7 @@ class Connection:
 
         if req.status_code == 200:
             _LOGGER.debug("ISY Response Received")
-            return req.text
+            return req.content.decode(encoding="utf-8", errors="ignore")
         if req.status_code == 404 and ok404:
             _LOGGER.debug("ISY Response Received")
             return ""

--- a/pyisy/eventreader.py
+++ b/pyisy/eventreader.py
@@ -49,7 +49,7 @@ class ISYEventReader:
             self._event_count += 1
             self._event_buffer = self._event_buffer[self._event_content_length :]
             self._event_content_length = None
-            events.append(body.decode("utf-8"))
+            events.append(body.decode(encoding="utf-8", errors="ignore"))
 
     def _receive_into_buffer(self, timeout):
         """Receive data on available on the socket.


### PR DESCRIPTION
Use UTF-8 encoding and ignore any errors when decoding the responses from Requests and from the event stream.

Related issue #124 - Fixes issue for V2.

cc: @bdraco  