### PR TITLE
[V3] Force UTF-8 decoding of responses and ignore errors

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -146,7 +146,7 @@ class Connection:
             ) as res:
                 if res.status == HTTP_OK:
                     _LOGGER.debug("ISY Response Received.")
-                    results = await res.text()
+                    results = await res.text(encoding="utf-8")
                     return results
                 if res.status == HTTP_NOT_FOUND:
                     if ok404:

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -146,7 +146,7 @@ class Connection:
             ) as res:
                 if res.status == HTTP_OK:
                     _LOGGER.debug("ISY Response Received.")
-                    results = await res.text(encoding="utf-8")
+                    results = await res.text(encoding="utf-8", errors="ignore")
                     return results
                 if res.status == HTTP_NOT_FOUND:
                     if ok404:

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -231,9 +231,7 @@ class WebSocketClient:
 
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
-                        await self._route_message(
-                            msg.data.decode(encoding="utf-8", errors="ignore")
-                        )
+                        await self._route_message(msg.data)
                     elif msg.type == aiohttp.WSMsgType.BINARY:
                         _LOGGER.warning("Unexpected binary message received.")
                     elif msg.type == aiohttp.WSMsgType.ERROR:

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -231,7 +231,9 @@ class WebSocketClient:
 
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
-                        await self._route_message(msg.data)
+                        await self._route_message(
+                            msg.data.decode(encoding="utf-8", errors="ignore")
+                        )
                     elif msg.type == aiohttp.WSMsgType.BINARY:
                         _LOGGER.warning("Unexpected binary message received.")
                     elif msg.type == aiohttp.WSMsgType.ERROR:

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -248,10 +248,10 @@ class WebSocketClient:
             aiohttp.client_exceptions.ServerDisconnectedError,
         ):
             _LOGGER.debug("Websocket Server Not Ready.")
-        except aiohttp.ClientConnectorError:
-            _LOGGER.error("Websocket Client Connector Error.")
+        except aiohttp.ClientConnectorError as err:
+            _LOGGER.error("Websocket Client Connector Error %s", err, exc_info=True)
         except Exception as err:
-            _LOGGER.error("Unexpected websocket error %s", err)
+            _LOGGER.error("Unexpected websocket error %s", err, exc_info=True)
         else:
             if isinstance(ws.exception(), asyncio.TimeoutError):
                 _LOGGER.debug("Websocket Timeout.")


### PR DESCRIPTION
Use UTF-8 encoding and ignore any errors when decoding the responses from Requests and from the event stream.

Related issue #124 - Fixes issue for V3

Needs to be tested to confirm no breaking changes before merge.

cc: @bdraco