### PR TITLE
Fix casting error on blank status sent during event

### DIFF
--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -202,7 +202,7 @@ class Nodes:
                 address,
             )
             return
-        value = value_from_xml(xmldoc, ATTR_ACTION)
+        value = value_from_xml(xmldoc, ATTR_ACTION, "")
         value = int(value) if value != "" else ISY_VALUE_UNKNOWN
         prec = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_PRECISION, "0")
         uom = attr_from_xml(xmldoc, ATTR_ACTION, ATTR_UNIT_OF_MEASURE, "")


### PR DESCRIPTION
Blank status values should be initially translated from the ISY as empty strings for consistency between the initial loading (`helpers.py`) and the events received in `nodes`.

In addition, failing to set a default causes a casting error trying to cast `int(None)`. 