### PR TITLE
Exclude Insteon battery-powered device states from Group/Scene status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Module now uses asynchronous communications via `asyncio` and `aiohttp` for communicating with the ISY. Updates are required to run the module in an asyncio event loop.
 - Connection with the ISY is no longer automatically initialized when the `ISY` or `Connection` classes are initialized. The `await isy.initialize()` function must be called when ready to connect. To test a connection only, you can use `Connection.test_connection()` after initializing at least a `Connection` class.
 - When sending a command, the node status is no longer updated presumptively using a `hint` value. If you are not using either the websocket or event stream, you will need to manually call `node.update(wait_time=UPDATE_INTERVAL)` for the node after calling the `node.send_cmd()` to update the value of the node.
+- Group/Scene Status now excludes the state of any Insteon battery powered devices (on ISYv5 firmware only). These devices often have stale states and only update when they change, not when other controllers in the scene change; this leads to incorrect or misleading Group/Scene states.
 
 #### Changed
 

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -731,6 +731,17 @@ INSTEON_TYPE_DIMMABLE = ["1."]
 INSTEON_SUBNODE_DIMMABLE = " 1"
 ZWAVE_CAT_DIMMABLE = ["109", "119", "186"]
 
+# Insteon Battery Devices - States are ignored when checking the status of a group.
+INSTEON_BATTERY_TYPE = ["0.16.", "0.17.", "0.18.", "16."]
+INSTEON_BATTERY_NODEDEFID = [
+    "BinaryAlarm",
+    "BinaryAlarm_ADV",
+    "BinaryControl",
+    "BinaryControl_ADV",
+    "RemoteLinc2",
+    "RemoteLinc2_ADV",
+]
+
 # Referenced from ISY-WSDK 4_fam.xml
 # Included for user translations in external modules.
 # This is the Node.zwave_props.category property.

--- a/pyisy/nodes/group.py
+++ b/pyisy/nodes/group.py
@@ -1,5 +1,10 @@
 """Representation of groups (scenes) from an ISY."""
-from ..constants import INSTEON_BATTERY_NODEDEFID, ISY_VALUE_UNKNOWN, PROTO_GROUP
+from ..constants import (
+    FAMILY_GENERIC,
+    INSTEON_BATTERY_NODEDEFID,
+    ISY_VALUE_UNKNOWN,
+    PROTO_GROUP,
+)
 from ..helpers import now
 from .nodebase import NodeBase
 
@@ -30,7 +35,7 @@ class Group(NodeBase):
         name,
         members=None,
         controllers=None,
-        family_id="6",
+        family_id=FAMILY_GENERIC,
         pnode=None,
     ):
         """Initialize a Group class."""

--- a/pyisy/nodes/group.py
+++ b/pyisy/nodes/group.py
@@ -1,5 +1,10 @@
 """Representation of groups (scenes) from an ISY."""
-from ..constants import ISY_VALUE_UNKNOWN, PROTO_GROUP
+from ..constants import (
+    _LOGGER,
+    INSTEON_BATTERY_NODEDEFID,
+    ISY_VALUE_UNKNOWN,
+    PROTO_GROUP,
+)
 from ..helpers import now
 from .nodebase import NodeBase
 
@@ -92,10 +97,11 @@ class Group(NodeBase):
             if (
                 self._nodes[node].status is not None
                 and self._nodes[node].status != ISY_VALUE_UNKNOWN
+                and self._nodes[node].node_def_id not in INSTEON_BATTERY_NODEDEFID
             )
         ]
         on_nodes = [node for node in valid_nodes if int(self._nodes[node].status) > 0]
-
+        _LOGGER.info("Group %s has these nodes on: %s", self.name, on_nodes)
         if on_nodes:
             self.group_all_on = len(on_nodes) == len(valid_nodes)
             self.status = 255

--- a/pyisy/nodes/group.py
+++ b/pyisy/nodes/group.py
@@ -1,10 +1,5 @@
 """Representation of groups (scenes) from an ISY."""
-from ..constants import (
-    _LOGGER,
-    INSTEON_BATTERY_NODEDEFID,
-    ISY_VALUE_UNKNOWN,
-    PROTO_GROUP,
-)
+from ..constants import INSTEON_BATTERY_NODEDEFID, ISY_VALUE_UNKNOWN, PROTO_GROUP
 from ..helpers import now
 from .nodebase import NodeBase
 
@@ -101,7 +96,6 @@ class Group(NodeBase):
             )
         ]
         on_nodes = [node for node in valid_nodes if int(self._nodes[node].status) > 0]
-        _LOGGER.info("Group %s has these nodes on: %s", self.name, on_nodes)
         if on_nodes:
             self.group_all_on = len(on_nodes) == len(valid_nodes)
             self.status = 255


### PR DESCRIPTION
Group/Scene Status now excludes the state of any Insteon battery powered devices (on ISYv5 firmware only). These devices often have stale states and only update when they change, not when other controllers in the scene change; this leads to incorrect or misleading Group/Scene states.

This applies to ISYv5 firmware only because only the `NodeDefID` property is used to identify battery powered devices; this is to prevent the need for `startswith()` lookups for device types (used in ISYv4 where `NodeDefID`'s are not available), which would cause additional minor performance issues whenever a group status needs to be updated.

Fixes #153.