### PR TITLE
Allow renaming of nodes and groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Module can now be used/tested from the command-line with the new `__main__.py` script; you can test a connection with `python3 -m pyisy http://your-isy-url:80 username password`.
 - A new helper function has been added to create an `aiohttp.ClientSession` compliant with the ISY: `Connection.get_new_client_session(use_https, tls_ver=1.1)` will return a web session that can be passed to the init functions of `ISY` and `Connection` classes.
+- Allow renaming of nodes and groups for ISY v5.2.0 or later using the `node.rename()` method.
 
 ### [v2.1.0] - Property Updates, Timestamps, Status Handling, and more...
 
@@ -20,12 +21,11 @@
 - `Node.is_dimmable` will only include the first subnode for Insteon devices in type 1. This should represent the main (load) button for KeypadLincs and the light for FanLincs, all other subnodes (KPL buttons and Fan Motor) are not dimmable (fixes #110)
 - This removes the `log=` parameter when initializing new `Connection` and `ISY` class instances. Please update any loading functions you may use to remove this `log=` parameter.
 
-
 #### Changed / Fixed
 
 - Changed the default Status Property (`ST`) unit of measurement (UOM) to `ISY_PROP_NOT_SET = "-1"`: Some NodeServer and Z-Wave nodes do not make use of the `ST` (or status) property in the ISY and only report `aux_properties`; in addition, most NodeServer nodes do not report the `ST` property when all nodes are retrieved, they only report it when queried directly or in the Event Stream. Previously, there was no way to differentiate between Insteon Nodes that don't have a valid status yet (after ISY reboot) and the other types of nodes that don't report the property correctly since they both reported `ISY_VALUE_UNKNOWN`. The `ISY_PROP_NOT_SET` allows differentiation between the two conditions based on having a valid UOM or not. Fixes #98.
 - Rewrite the Node status update receiver: currently, when a Node's status is updated, the `formatted` property is not updated and the `uom`/`prec` are updated with separate functions from outside of the Node's class. This updates the receiver to pass a `NodeProperty` instance into the Node, and allows the Node to update all of it's properties if they've changed, before reporting the status change to the subscribers. This makes the `formatted` property actually useful.
-- Logging Cleanup: Removes reliance on `isy` parent objects to provide logger and uses a module-wide `_LOGGER`.  Everything will be logged under the `pyisy` namespace except Events. Events maintains a separate logger namespace to allow targeting in handlers of `pyisy.events`.
+- Logging Cleanup: Removes reliance on `isy` parent objects to provide logger and uses a module-wide `_LOGGER`. Everything will be logged under the `pyisy` namespace except Events. Events maintains a separate logger namespace to allow targeting in handlers of `pyisy.events`.
 
 #### Added
 

--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -167,6 +167,7 @@ PROP_UOM = "UOM"
 METHOD_GET = "get"
 METHOD_COMMAND = "cmd"
 
+URL_CHANGE = "change"
 URL_CLOCK = "time"
 URL_CONFIG = "config"
 URL_DEFINITIONS = "definitions"

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -26,8 +26,10 @@ from ..constants import (
     TAG_DESCRIPTION,
     TAG_IS_LOAD,
     TAG_LOCATION,
+    TAG_NAME,
     TAG_SPOKEN,
     UPDATE_INTERVAL,
+    URL_CHANGE,
     URL_NODES,
     URL_NOTES,
     XML_TRUE,
@@ -344,3 +346,24 @@ class NodeBase:
             cmd = CMD_OFF
             val = None
         return await self.send_cmd(cmd, val)
+
+    async def rename(self, new_name):
+        """
+        Rename the node or group in the ISY.
+
+        Note: Feature was added in ISY v5.2.0, this will fail on earlier versions.
+        """
+
+        # /rest/nodes/<nodeAddress>/change?name=<newName>
+        req_url = self.isy.conn.compile_url(
+            [URL_NODES, self._id, URL_CHANGE], query={TAG_NAME: new_name},
+        )
+        if not await self.isy.conn.request(req_url):
+            _LOGGER.warning(
+                "ISY could not update name for %s.", self._id,
+            )
+            return False
+        _LOGGER.debug("ISY renamed %s to %s.", self._id, new_name)
+
+        self._name = new_name
+        return True


### PR DESCRIPTION
Adds support for renaming Nodes and Groups on the ISY from within PyISY.

Fixes #129.