### PR TITLE
Expose Folder Property for Groups and Nodes

### DIFF
--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -519,6 +519,17 @@ class Nodes:
             self.ntypes,
         )
 
+    def get_folder(self, address):
+        """Return the folder of a given node address."""
+        parent = self.nparents[self.addresses.index(address)]
+        if parent is None:
+            # Node is in the root folder.
+            return None
+        parent_index = self.addresses.index(parent)
+        if self.ntypes[parent_index] != TAG_FOLDER:
+            return self.get_folder(parent)
+        return self.nnames[parent_index]
+
     @property
     def children(self):
         """Return the children of the class."""

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -93,6 +93,11 @@ class NodeBase:
         return self._family
 
     @property
+    def folder(self):
+        """Return the folder of the current node as a property."""
+        return self._nodes.get_folder(self.address)
+
+    @property
     def is_load(self):
         """Return the isLoad property of the node from it's notes."""
         if self._notes is None:


### PR DESCRIPTION
Exposes a `node.folder` property for each node and group to get the name of the folder containing the node or group of nodes.

Exposes `nodes.get_folder(address)` function on the node manager for the same purpose.