### PR TITLE
Update status for battery level nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - hooks:
           - args:
                 [
-                    "--ignore-words-list=pyisy,hass,isy,nid,dof,dfof,don,dfon,tim,automic,automicus",
+                    "--ignore-words-list=pyisy,hass,isy,nid,dof,dfof,don,dfon,tim,automic,automicus,BATLVL",
                     '--skip="./.*,*.json"',
                     --quiet-level=2,
                 ]

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -74,7 +74,7 @@ def parse_xml_properties(xmldoc):
                 result.uom = UOM_SECONDS
             aux_props[prop_id] = result
 
-    return state, aux_props
+    return state, aux_props, state_set
 
 
 def value_from_xml(xml, tag_name, default=None):

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -24,6 +24,7 @@ from ..constants import (
     ISY_VALUE_UNKNOWN,
     NC_NODE_ERROR,
     NODE_CHANGED_ACTIONS,
+    PROP_BATTERY_LEVEL,
     PROP_COMMS_ERROR,
     PROP_RAMP_RATE,
     PROP_STATUS,
@@ -265,6 +266,12 @@ class Nodes:
         ):
             # Clear a previous comms error
             del node.aux_properties[PROP_COMMS_ERROR]
+        if cntrl == PROP_BATTERY_LEVEL and node.is_battery_node:
+            # Update the state if this is a battery node
+            node.update_state(
+                NodeProperty(PROP_STATUS, value, prec, uom, formatted, address)
+            )
+            _LOGGER.debug("ISY Updated Node: " + address)
         elif cntrl not in EVENT_PROPS_IGNORED:
             node.update_property(node_property)
         node.control_events.notify(node_property)
@@ -333,7 +340,7 @@ class Nodes:
                     if address in self.addresses:
                         self.get_by_id(address).update(xmldoc=feature)
                         continue
-                    state, aux_props = parse_xml_properties(feature)
+                    state, aux_props, state_set = parse_xml_properties(feature)
                     self.insert(
                         address,
                         nname,
@@ -352,6 +359,7 @@ class Nodes:
                             node_server=node_server,
                             protocol=protocol,
                             family_id=family,
+                            state_set=state_set,
                         ),
                         ntype,
                     )

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -93,6 +93,7 @@ class Node(NodeBase):
         node_server=None,
         protocol=None,
         family_id=None,
+        state_set=True,
     ):
         """Initialize a Node class."""
         self._enabled = enabled if enabled is not None else True
@@ -106,6 +107,7 @@ class Node(NodeBase):
         self._uom = state.uom
         self._zwave_props = zwave_props
         self.control_events = EventEmitter()
+        self._is_battery_node = not state_set
         super().__init__(
             nodes,
             address,
@@ -135,6 +137,15 @@ class Node(NodeBase):
     def formatted(self):
         """Return the formatted value with units, if provided."""
         return self._formatted
+
+    @property
+    def is_battery_node(self):
+        """
+        Confirm if this is a battery node or a normal node.
+
+        Battery nodes do not provide a 'ST' property, only 'BATLVL'.
+        """
+        return self._is_battery_node
 
     @property
     def is_dimmable(self):
@@ -357,7 +368,7 @@ class Node(NodeBase):
             return
 
         self._last_update = now()
-        state, aux_props = parse_xml_properties(xmldoc)
+        state, aux_props, _ = parse_xml_properties(xmldoc)
         self._aux_properties.update(aux_props)
         self.update_state(state)
         _LOGGER.debug("ISY updated node: %s", self._id)


### PR DESCRIPTION
Fixed #306.

Some Battery Level nodes only provide a BATLVL property instead of a ST state property. On initial loading this is set as the state the node will was never updating the status because it is waiting for a ST update that never arrives. 

Added new `is_battery_node` property to record if no `ST` is present upon initial loading and use this property when a `BATTLVL` control message is received to update the state.