### PR TITLE
Update error handling and debug logging

### DIFF
--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -10,7 +10,7 @@ from .constants import (
     URL_NETWORK,
     URL_RESOURCES,
 )
-from .exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
+from .exceptions import XML_ERRORS, XML_PARSE_ERROR
 from .helpers import value_from_xml
 
 
@@ -64,8 +64,8 @@ class NetworkResources:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            _LOGGER.error("%s: NetworkResources", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR)
+            _LOGGER.error("%s: NetworkResources, resources not loaded", XML_PARSE_ERROR)
+            return
 
         features = xmldoc.getElementsByTagName(TAG_NET_RULE)
         for feature in features:

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -301,6 +301,9 @@ class Nodes:
                 # Get Node Information
                 address = value_from_xml(feature, TAG_ADDRESS)
                 nname = value_from_xml(feature, TAG_NAME)
+
+                _LOGGER.debug("Parsing %s: %s [%s]", ntype, nname, address)
+
                 nparent = value_from_xml(feature, TAG_PARENT)
                 pnode = value_from_xml(feature, TAG_PRIMARY_NODE)
                 family = value_from_xml(feature, TAG_FAMILY)

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -23,7 +23,7 @@ from ..constants import (
     XML_ON,
     XML_TRUE,
 )
-from ..exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
+from ..exceptions import XML_ERRORS, XML_PARSE_ERROR
 from ..helpers import attr_from_element, now, value_from_xml
 from ..nodes import NodeIterator as ProgramIterator
 from .folder import Folder
@@ -192,8 +192,8 @@ class Programs:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS:
-            _LOGGER.error("%s: Programs", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR)
+            _LOGGER.error("%s: Programs, programs not loaded", XML_PARSE_ERROR)
+            return
 
         plastup = now()
 
@@ -203,6 +203,9 @@ class Programs:
             # id, name, and status
             address = attr_from_element(feature, ATTR_ID)
             pname = value_from_xml(feature, TAG_NAME)
+
+            _LOGGER.debug("Parsing Program/Folder: %s [%s]", pname, address)
+
             pparent = attr_from_element(feature, ATTR_PARENT)
             pstatus = attr_from_element(feature, ATTR_STATUS) == XML_TRUE
 


### PR DESCRIPTION
Include additional debug logging when initially parsing nodes and programs (Fixes #283)

Do not throw exceptions if there is an error parsing XML for Programs, Variables, or Network Connections--effectively making these optional. This should eliminate need to create at least one of each (Fixes #285)