### PR TITLE
Bug Fixes: Verbose Logging, WS Handshake Error, Missing Eisy DevTypes

### DIFF
--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -201,6 +201,8 @@ class WebSocketClient:
                 await self.isy.programs.update()
         elif cntrl == "_3":  # Node Changed/Updated
             self.isy.nodes.node_changed_received(xmldoc)
+        elif cntrl == "_5":  # System Status Changed
+            self.isy.system_status_changed_received(xmldoc)
 
     def update_received(self, xmldoc):
         """Set the socket ID."""
@@ -244,6 +246,8 @@ class WebSocketClient:
             aiohttp.client_exceptions.ServerDisconnectedError,
         ):
             _LOGGER.debug("Websocket Server Not Ready.")
+        except aiohttp.client_exceptions.WSServerHandshakeError as err:
+            _LOGGER.warning("Web socket server response error: %s", err.message)
         # pylint: disable=broad-except
         except Exception as err:
             _LOGGER.error("Unexpected websocket error %s", err, exc_info=True)

--- a/pyisy/logging.py
+++ b/pyisy/logging.py
@@ -23,7 +23,8 @@ def enable_logging(
 
             # basicConfig must be called after importing colorlog in order to
             # ensure that the handlers it sets up wraps the correct streams.
-            logging.basicConfig(level=LOG_LEVEL)
+            logging.basicConfig(level=level)
+            logging.addLevelName(LOG_VERBOSE, "VERBOSE")
 
             colorfmt = f"%(log_color)s{LOG_FORMAT}%(reset)s"
             logging.getLogger().handlers[0].setFormatter(
@@ -32,6 +33,7 @@ def enable_logging(
                     datefmt=LOG_DATE_FORMAT,
                     reset=True,
                     log_colors={
+                        "VERBOSE": "blue",
                         "DEBUG": "cyan",
                         "INFO": "green",
                         "WARNING": "yellow",

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -353,9 +353,11 @@ class Nodes:
                 if family is not None:
                     if family in (FAMILY_ZWAVE, FAMILY_ZMATTER_ZWAVE):
                         protocol = PROTO_ZWAVE
-                        zwave_props = ZWaveProperties(
-                            feature.getElementsByTagName(TAG_DEVICE_TYPE)[0]
-                        )
+                        zwave_prop_xml = feature.getElementsByTagName(TAG_DEVICE_TYPE)
+                        if zwave_prop_xml:
+                            zwave_props = ZWaveProperties.from_xml(zwave_prop_xml[0])
+                        else:
+                            ZWaveProperties()
                     elif family in (FAMILY_BRULTECH, FAMILY_RCS):
                         protocol = PROTO_ZIGBEE
                     elif family == FAMILY_NODESERVER:


### PR DESCRIPTION
- Fix verbose logging broken after change to `colorlog`
- Add warning handler for `WSServerHandshakeError` after linter order change
- Re-add dropped handler for system status changes
- Make `<devtype>` tag optional for Z-Wave devices due to malformed eisy node responses.