### PR TITLE
Support Insteon Heat Pump Thermostats

### DIFF
--- a/pyisy/constants.py
+++ b/pyisy/constants.py
@@ -760,8 +760,21 @@ INSTEON_RAMP_RATES = {
 }
 
 # Thermostat Types/Categories. 4.8 Trane, 5.3 venstar, 5.10 Insteon Wireless,
-#  5.11 Insteon, 5.17 Insteon (EU), 5.18 Insteon (Aus/NZ)
-INSTEON_TYPE_THERMOSTAT = ["4.8", "5.3", "5.10", "5.11", "5.14", "5.17", "5.18"]
+#  5.0x0B, 0x0F, 0x10, 0x13, 0x14, 0x15 - Insteon (alt. frequencies)
+INSTEON_TYPE_THERMOSTAT = [
+    "4.8",
+    "5.3",
+    "5.10",
+    "5.11",
+    "5.14",
+    "5.15",
+    "5.16",
+    "5.17",
+    "5.18",
+    "5.19",
+    "5.20",
+    "5.21",
+]
 ZWAVE_CAT_THERMOSTAT = ["140"]
 
 # Other special categories or types


### PR DESCRIPTION
Add support for additional thermostat types as per https://github.com/home-assistant/core/issues/86959

Documentation:
http://cache.insteon.com/documentation/2732-xx2-en.pdf