### PR TITLE
Use initial ok404 parameter on request retry

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -209,7 +209,7 @@ class Connection:
             # sleep to allow the ISY to catch up
             await asyncio.sleep(RETRY_BACKOFF[retries])
             # recurse to try again
-            retry_result = await self.request(url, retries + 1, ok404=False)
+            retry_result = await self.request(url, retries + 1, ok404=ok404)
             return retry_result
         # fail for good
         _LOGGER.error(


### PR DESCRIPTION
Use the originally-passed value for `ok404` when retrying a command, instead of resetting to `False`