### PR TITLE
Wait for ISY to be ready when retrying commands

### DIFF
--- a/pyisy/__main__.py
+++ b/pyisy/__main__.py
@@ -94,7 +94,7 @@ async def main(url, username, password, tls_ver, events, node_servers):
             node_changed_subscriber = isy.nodes.status_events.subscribe(
                 node_changed_handler
             )
-            system_status_subscriber = isy.status_events.subscribe(
+            system_status_subscriber = isy.system_status.status_events.subscribe(
                 system_status_handler
             )
         while True:

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -203,7 +203,7 @@ class WebSocketClient:
         elif cntrl == "_3":  # Node Changed/Updated
             self.isy.nodes.node_changed_received(xmldoc)
         elif cntrl == "_5":  # System Status Changed
-            self.isy.system_status_changed_received(xmldoc)
+            self.isy.conn.system_status.change_received(xmldoc)
         elif cntrl == "_7":  # Progress report, device programming event
             self.isy.nodes.progress_report_received(xmldoc)
 

--- a/pyisy/isy.py
+++ b/pyisy/isy.py
@@ -6,7 +6,6 @@ from .clock import Clock
 from .configuration import Configuration
 from .connection import Connection
 from .constants import (
-    ATTR_ACTION,
     CMD_X10,
     ES_CONNECTED,
     ES_RECONNECT_FAILED,
@@ -14,14 +13,12 @@ from .constants import (
     ES_START_UPDATES,
     ES_STOP_UPDATES,
     PROTO_ISY,
-    SYSTEM_BUSY,
-    SYSTEM_STATUS,
     URL_QUERY,
     X10_COMMANDS,
 )
 from .events.tcpsocket import EventStream
 from .events.websocket import WebSocketClient
-from .helpers import EventEmitter, value_from_xml
+from .helpers import EventEmitter
 from .logging import _LOGGER, enable_logging
 from .networking import NetworkResources
 from .nodes import Nodes
@@ -112,8 +109,7 @@ class ISY:
         self.networking = None
         self._hostname = address
         self.connection_events = EventEmitter()
-        self.status_events = EventEmitter()
-        self.system_status = SYSTEM_BUSY
+        self.system_status = self.conn.system_status
         self.loop = asyncio.get_running_loop()
         self._uuid = None
 
@@ -279,11 +275,3 @@ class ISY:
                 _LOGGER.info("ISY Sent X10 Command: %s To: %s", cmd, address)
             else:
                 _LOGGER.error("ISY Failed to send X10 Command: %s To: %s", cmd, address)
-
-    def system_status_changed_received(self, xmldoc):
-        """Handle System Status events from an event stream message."""
-        action = value_from_xml(xmldoc, ATTR_ACTION)
-        if not action or action not in SYSTEM_STATUS:
-            return
-        self.system_status = action
-        self.status_events.notify(action)

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -593,8 +593,7 @@ class Nodes:
             i = self.addresses.index(address)
         except ValueError:
             return None
-        else:
-            return self.get_by_index(i)
+        return self.get_by_index(i)
 
     def get_by_index(self, i):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools~=62.3", "wheel","setuptools_scm[toml]>=6.2",]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyisy"
+name = "pyisy-beta"
 description = "Python module to talk to ISY devices from UDI."
 license     = {text = "Apache-2.0"}
 keywords = ["home", "automation", "isy", "isy994", "isy-994", "UDI", "polisy", "eisy"]


### PR DESCRIPTION
Use the system status reported by the websocket to hold off on retrying a command until the system reports that it is ready.

This will always still *try* the command first, even if the system has reported it's busy. If the command returns a `404` error, then instead of just failing or using the throttled backoff for the retry, it will wait up to 5 seconds for the ISY to report it is `NOT_BUSY` before retrying again. If the system is still busy after 5 seconds, an ISYConnectionError is raised.

Fixes #184 