### PR TITLE
Remove name-based node indexing (names may not be unique)

### DIFF
--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -59,7 +59,6 @@ class NetworkResources:
         self.addresses: list[int] = []
         self._address_index: dict[int, int] = {}
         self.nnames: list[str] = []
-        self._nnames_index: dict[str, int] = {}
         self.nobjs: list[NetworkCommand] = []
 
         if xml is not None:
@@ -87,7 +86,6 @@ class NetworkResources:
             self.addresses.append(address)
             self._address_index[address] = len(self.addresses) - 1
             self.nnames.append(nname)
-            self._nnames_index[nname] = len(self.nnames) - 1
             self.nobjs.append(nobj)
 
         _LOGGER.info("ISY Loaded Network Resources Commands")
@@ -138,8 +136,11 @@ class NetworkResources:
 
         val: String representing command name
         """
-        ind = self._nnames_index.get(val)
-        return None if ind is None else self.get_by_index(ind)
+        try:
+            ind = self.nnames.index(val)
+            return self.get_by_index(ind)
+        except (ValueError, KeyError):
+            return None
 
     def get_by_index(self, val: int) -> NetworkCommand | None:
         """

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -120,7 +120,6 @@ class Nodes:
         ntypes: list[str] | None = None,
         xml: str | None = None,
         _address_index: dict[str, int] | None = None,  # Internal use only
-        _nnames_index: dict[str, int] | None = None,  # Internal use only
     ) -> None:
         """Initialize the Nodes ISY Node Manager class."""
         self.isy = isy
@@ -129,7 +128,6 @@ class Nodes:
         self.addresses: list[str] = []
         self._address_index: dict[str, int] = {}
         self.nnames: list[str] = []
-        self._nnames_index: dict[str, int] = {}
         self.nparents: list[str] = []
         self.nobjs: list[Node] = []
         self.ntypes: list[str] = []
@@ -145,7 +143,6 @@ class Nodes:
             self._address_index = _address_index or {address: i for i, address in enumerate(addresses)}
         if nnames is not None:
             self.nnames = nnames
-            self._nnames_index = _nnames_index or {name: i for i, name in enumerate(nnames)}
         if nparents is not None:
             self.nparents = nparents
         if nobjs is not None:
@@ -544,7 +541,6 @@ class Nodes:
         self.addresses.append(address)
         self._address_index[address] = len(self.addresses) - 1
         self.nnames.append(nname)
-        self._nnames_index[nname] = len(self.nnames) - 1
         self.nparents.append(nparent)
         self.ntypes.append(ntype)
         self.nobjs.append(nobj)
@@ -553,14 +549,16 @@ class Nodes:
         """Navigate through the node tree. Can take names or IDs."""
         if val in self._address_index:
             fun = self.get_by_id
-        elif val in self._nnames_index:
-            fun = self.get_by_name
         else:
             try:
-                val = int(val)
-                fun = self.get_by_index
+                self.nnames.index(val)
+                fun = self.get_by_name
             except ValueError:
-                fun = None
+                try:
+                    val = int(val)
+                    fun = self.get_by_index
+                except ValueError:
+                    fun = None
 
         if fun:
             output = None
@@ -583,9 +581,9 @@ class Nodes:
 
         |  val: String representing name to look for.
         """
-        i = self._nnames_index.get(val)
-        if i is not None and (self.root is None or self.nparents[i] == self.root):
-            return self.get_by_index(i)
+        for i in range(len(self.addresses)):
+            if (self.root is None or self.nparents[i] == self.root) and self.nnames[i] == val:
+                return self.get_by_index(i)
         return None
 
     def get_by_id(self, address: str) -> Node | Nodes | None:
@@ -615,7 +613,6 @@ class Nodes:
             nobjs=self.nobjs,
             ntypes=self.ntypes,
             _address_index=self._address_index,
-            _nnames_index=self._nnames_index,
         )
 
     def get_folder(self, address: str) -> str | None:

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -76,7 +76,6 @@ class Programs:
         ptypes: list[str] | None = None,
         xml: str | None = None,
         _address_index: dict[str, int] | None = None,
-        _pnames_index: dict[str, int] | None = None,
     ) -> None:
         """Initialize the Programs ISY programs manager class."""
         self.isy = isy
@@ -85,7 +84,6 @@ class Programs:
         self.addresses: list[str] = []
         self._address_index: dict[str, int] = {}
         self.pnames: list[str] = []
-        self._pnames_index: dict[str, int] = {}
         self.pparents: list[str] = []
         self.pobjs: list[Program | Folder] = []
         self.ptypes: list[str] = []
@@ -99,7 +97,6 @@ class Programs:
             self._address_index = _address_index or {address: i for i, address in enumerate(addresses)}
         if pnames is not None:
             self.pnames = pnames
-            self._pnames_index = _pnames_index or {name: i for i, name in enumerate(pnames)}
         if pparents is not None:
             self.pparents = pparents
         if pobjs is not None:
@@ -308,7 +305,6 @@ class Programs:
         self.addresses.append(address)
         self._address_index[address] = len(self.addresses) - 1
         self.pnames.append(pname)
-        self._pnames_index[pname] = len(self.pnames) - 1
         self.pparents.append(pparent)
         self.ptypes.append(ptype)
         self.pobjs.append(pobj)
@@ -321,14 +317,16 @@ class Programs:
         """
         if val in self._address_index:
             fun = self.get_by_id
-        elif val in self._pnames_index:
-            fun = self.get_by_name
         else:
             try:
-                val = int(val)
-                fun = self.get_by_index
-            except (TypeError, ValueError) as err:
-                raise KeyError("Unrecognized Key: " + str(val)) from err
+                self.pnames.index(val)
+                fun = self.get_by_name
+            except ValueError:
+                try:
+                    val = int(val)
+                    fun = self.get_by_index
+                except (TypeError, ValueError) as err:
+                    raise KeyError("Unrecognized Key: " + str(val)) from err
         try:
             return fun(val)
         except (ValueError, KeyError, IndexError):
@@ -344,9 +342,9 @@ class Programs:
 
         |  val: The name of the child program/folder to look for.
         """
-        i = self._pnames_index.get(val)
-        if i is not None and (self.root is None or self.pparents[i] == self.root):
-            return self.get_by_index(i)
+        for i in range(len(self.addresses)):
+            if (self.root is None or self.pparents[i] == self.root) and self.pnames[i] == val:
+                return self.get_by_index(i)
         return None
 
     def get_by_id(self, address: str) -> Program | Folder | Programs:
@@ -373,7 +371,6 @@ class Programs:
                 pobjs=self.pobjs,
                 ptypes=self.ptypes,
                 _address_index=self._address_index,
-                _pnames_index=self._pnames_index,
             )
         return self.pobjs[i]
 


### PR DESCRIPTION
partial revert of #434, #427, #405 as it caused a regression https://github.com/home-assistant/core/issues/144045

Addresses are unique and that works well to avoid most of the linear searches but names can have collisions