### PR TITLE
Retry on spurious 404 from command-issuing endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Lint stack (all run by pre-commit):
 
 - Uses an asyncio Semaphore to enforce ISY-994's strict simultaneous-connection limit (2 HTTPS / 5 HTTP); `increase_available_connections()` raises it for IoX.
 - `request()` handles retries with backoff, swallows expected 404s when `ok404=True`, and force-decodes responses as UTF-8 with `errors="ignore"` (ISY firmware emits invalid UTF-8 in some node names — see CHANGELOG #126).
+- `request(retry404=True)` makes the 404 branch fall into the retry/backoff loop instead of returning `None`. Use this from command-issuing callers (`NodeBase.send_cmd`, `Folder.send_cmd`, `Variable.set_value`, `ISY.query`, `ISY.send_x10_cmd`) — the ISY-994 firmware emits spurious 404s on `/rest/nodes/.../cmd/...` when its Insteon network is overwhelmed (#184). Don't enable on read paths; the existing retry budget is bounded (5 retries, ~3.4s) but multiplying that across status polls is wasteful.
 - `get_new_client_session(use_https, tls_ver)` and `get_sslcontext()` are module-level helpers because the ISY-994 supports legacy TLS 1.1 and weak ciphers; consumers (HA Core) need to obtain a session compatible with the device.
 
 ### Event streams (`events/`)

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -142,8 +142,21 @@ class Connection:
 
         return url
 
-    async def request(self, url: str, retries: int = 0, ok404: bool = False, delay: int = 0) -> str | None:
-        """Execute request to ISY REST interface."""
+    async def request(
+        self,
+        url: str,
+        retries: int = 0,
+        ok404: bool = False,
+        retry404: bool = False,
+        delay: int = 0,
+    ) -> str | None:
+        """Execute request to ISY REST interface.
+
+        retry404: ISY-994 returns spurious 404s on `/rest/nodes/.../cmd/...`
+        when the Insteon network is overwhelmed. Pass True from command-issuing
+        callers so a 404 falls into the existing retry/backoff loop instead of
+        being treated as a permanent failure.
+        """
         _LOGGER.debug("ISY Request: %s", url)
         if delay:
             await asyncio.sleep(delay)
@@ -171,9 +184,18 @@ class Connection:
                         _LOGGER.debug("ISY Response Received %s", endpoint)
                         res.release()
                         return ""
-                    _LOGGER.error("ISY Reported an Invalid Command Received %s", endpoint)
-                    res.release()
-                    return None
+                    if retry404:
+                        # ISY-994 emits spurious 404s when the Insteon network
+                        # is busy; fall through to the retry/backoff loop.
+                        _LOGGER.debug(
+                            "ISY returned 404 for %s; controller may be busy, will retry",
+                            endpoint,
+                        )
+                        res.release()
+                    else:
+                        _LOGGER.error("ISY Reported an Invalid Command Received %s", endpoint)
+                        res.release()
+                        return None
                 if res.status == HTTP_UNAUTHORIZED:
                     _LOGGER.error("Invalid credentials provided for ISY connection.")
                     res.release()
@@ -216,7 +238,7 @@ class Connection:
             # sleep to allow the ISY to catch up
             await asyncio.sleep(RETRY_BACKOFF[retries])
             # recurse to try again
-            return await self.request(url, retries + 1, ok404=ok404)
+            return await self.request(url, retries + 1, ok404=ok404, retry404=retry404)
         # fail for good
         _LOGGER.error(
             "Bad ISY Request: (%s) Failed after %s retries.",

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -147,8 +147,8 @@ class Connection:
         url: str,
         retries: int = 0,
         ok404: bool = False,
-        retry404: bool = False,
         delay: int = 0,
+        retry404: bool = False,
     ) -> str | None:
         """Execute request to ISY REST interface.
 

--- a/pyisy/isy.py
+++ b/pyisy/isy.py
@@ -261,7 +261,7 @@ class ISY:
         if address is not None:
             req_path.append(address)
         req_url = self.conn.compile_url(req_path)
-        if not await self.conn.request(req_url):
+        if not await self.conn.request(req_url, retry404=True):
             _LOGGER.warning("Error performing query.")
             return False
         _LOGGER.debug("ISY Query requested successfully.")
@@ -277,7 +277,7 @@ class ISY:
         if cmd in X10_COMMANDS:
             command = X10_COMMANDS.get(cmd)
             req_url = self.conn.compile_url([CMD_X10, address, str(command)])
-            result = await self.conn.request(req_url)
+            result = await self.conn.request(req_url, retry404=True)
             if result is not None:
                 _LOGGER.info("ISY Sent X10 Command: %s To: %s", cmd, address)
             else:

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -261,7 +261,7 @@ class NodeBase:
         if _uom:
             req.append(_uom)
         req_url = self.isy.conn.compile_url(req, query)
-        if not await self.isy.conn.request(req_url):
+        if not await self.isy.conn.request(req_url, retry404=True):
             _LOGGER.warning(
                 "ISY could not send %s command to %s.",
                 COMMAND_FRIENDLY_NAME.get(cmd),
@@ -286,7 +286,8 @@ class NodeBase:
     async def disable(self) -> bool:
         """Send command to the node to disable it."""
         if not await self.isy.conn.request(
-            self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_DISABLE])
+            self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_DISABLE]),
+            retry404=True,
         ):
             _LOGGER.warning("ISY could not %s %s.", CMD_DISABLE, self._id)
             return False
@@ -294,7 +295,10 @@ class NodeBase:
 
     async def enable(self) -> bool:
         """Send command to the node to enable it."""
-        if not await self.isy.conn.request(self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_ENABLE])):
+        if not await self.isy.conn.request(
+            self.isy.conn.compile_url([URL_NODES, str(self._id), CMD_ENABLE]),
+            retry404=True,
+        ):
             _LOGGER.warning("ISY could not %s %s.", CMD_ENABLE, self._id)
             return False
         return True
@@ -355,7 +359,7 @@ class NodeBase:
             [URL_NODES, self._id, URL_CHANGE],
             query={TAG_NAME: new_name},
         )
-        if not await self.isy.conn.request(req_url):
+        if not await self.isy.conn.request(req_url, retry404=True):
             _LOGGER.warning(
                 "ISY could not update name for %s.",
                 self._id,

--- a/pyisy/programs/folder.py
+++ b/pyisy/programs/folder.py
@@ -146,7 +146,7 @@ class Folder:
     async def send_cmd(self, command: str) -> bool:
         """Run the appropriate clause of the object."""
         req_url = self.isy.conn.compile_url([URL_PROGRAMS, str(self._id), command])
-        result = await self.isy.conn.request(req_url)
+        result = await self.isy.conn.request(req_url, retry404=True)
         if not result:
             _LOGGER.warning('ISY could not call "%s" on program: %s', command, self._id)
             return False

--- a/pyisy/variables/variable.py
+++ b/pyisy/variables/variable.py
@@ -217,7 +217,7 @@ class Variable:
                 str(value),
             ]
         )
-        if not await self.isy.conn.request(req_url):
+        if not await self.isy.conn.request(req_url, retry404=True):
             _LOGGER.warning(
                 "ISY could not set variable%s: %s.%s",
                 " init value" if init else "",


### PR DESCRIPTION
## Summary

ISY-994 firmware emits spurious HTTP 404s on `/rest/nodes/.../cmd/...` when its Insteon network is temporarily overwhelmed. The retry/backoff plumbing in `Connection.request()` already exists (`MAX_RETRIES=5`, `RETRY_BACKOFF=[0.01, 0.10, 0.25, 1, 2]s`), but the 404 branch returns `None` unconditionally, so the retry loop never engages. Per #184, the user-facing symptom is bulk light commands silently failing with `"ISY Reported an Invalid Command Received"` log spam and lights that don't turn on.

This is the narrower path the original #184 thread converged on, after the broader BUSY-gated approach in #380 was found to miss the actual ISY-994 failure mode (controller emits 404s without firing the SYSTEM_BUSY event the gate depended on).

## Changes

`Connection.request()`:
- New `retry404: bool = False` parameter. When set, a 404 logs at DEBUG ("controller may be busy, will retry") and falls into the existing retry/backoff loop instead of returning `None`.
- Threaded through the recursion. Independent of `ok404` (which means "404 is normal here", not "retry"). Initial-connect fail-fast (`retries=None`) is preserved.

Threaded `retry404=True` into the command-issuing callers that hit the Insteon-mesh endpoints:
- `NodeBase.send_cmd` / `disable` / `enable` / `rename` — `/rest/nodes/...`
- `Folder.send_cmd` in programs — `/rest/programs/...`
- `Variable.set_value` — `/rest/vars/...`
- `ISY.query` — `/rest/query`
- `ISY.send_x10_cmd` — `/rest/X10/...`

Plus a CLAUDE.md note documenting the flag's intended scope.

## Intentionally NOT changed

- **Z-Wave config setters** (`set_zwave_parameter`, `set_zwave_lock_code`, `delete_zwave_lock_code`). They go to `/rest/zwave/...` which doesn't traverse the Insteon mesh that produces the spurious 404s. Worst case for an actual typo would be ~3.4s of wasted retry; can revisit if a real reproducer surfaces.
- **Read paths** (`Node.update`, `Node.get_zwave_parameter`, `NodeBase.get_notes`, status fetches). The retry budget is bounded but multiplying it across status polls is wasteful.
- **`ok404` callers** (`ping`, `get_network`). Unchanged — those mean "404 is a normal capability-probe outcome", which is a different failure model.

## Behavioral envelope

- Before: 404 on a command → 1 ERROR log, immediate `False` return, command silently dropped.
- After (transient busy 404): up to 5 DEBUG logs, ~3.4s retry budget, command succeeds on a later attempt; on permanent failure, the existing `"Bad ISY Request: (%s) Failed after %s retries."` ERROR fires.
- After (genuinely bad address): same 5 retries / ~3.4s wasted before final ERROR, vs. immediate fail today. Cost is bounded and developer-time-only.
- Initial-connect path (`retries=None`) is unchanged — still raises `ISYConnectionError` on any 404 it encounters.

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [ ] Smoke against a real ISY: trigger a multi-light automation that previously logged `ISY Reported an Invalid Command Received`; verify the ERROR no longer fires and the lights actually turn on
- [ ] Sanity-check a deliberately-bad node address still fails (slower, but still fails) without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)