### PR TITLE
Bump minimum Python version to 3.11 and remove outdated dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ import sphinx_rtd_theme
 sys.path.insert(0, os.path.abspath(".."))
 
 MOCK_MODULES = [
-    "dateutil",
     "aiohttp",
 ]
 for mod_name in MOCK_MODULES:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,12 +46,11 @@ See the :ref:`PyISY Tutorial<tutorial>` for guidance on how to use the module.
 Requirements
 ~~~~~~~~~~~~
 
-This package requires three other packages, also available from pip. They are
+This package requires two other packages, also available from pip. They are
 installed automatically when PyISY is installed using pip.
 
-* `requests <http://docs.python-requests.org/en/latest/>`_
-* `dateutil <https://dateutil.readthedocs.io/en/stable/>`_
 * `aiohttp <https://docs.aiohttp.org/en/stable/>`_
+* `colorlog <https://github.com/borntyping/python-colorlog>`_
 
 Contents
 ~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,7 +106,7 @@ everything up. This can be done using the :class:`Connection<pyisy.connection.Co
     )
 
     try:
-        with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             isy_conf_xml = await isy_conn.test_connection()
     except (ISYInvalidAuthError, ISYConnectionError):
         _LOGGER.error(

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -182,7 +182,7 @@ class Connection:
                     _LOGGER.warning("ISY too busy to process request %s", endpoint)
                     res.release()
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Timeout while trying to connect to the ISY.")
         except (
             aiohttp.ClientOSError,

--- a/pyisy/events/tcpsocket.py
+++ b/pyisy/events/tcpsocket.py
@@ -282,7 +282,7 @@ class EventStream:
             for message in events:
                 try:
                     self._route_message(message)
-                except Exception as ex:  # pylint: disable=broad-except  # noqa: PERF203
+                except Exception as ex:  # pylint: disable=broad-except
                     _LOGGER.warning("PyISY encountered while routing message '%s': %s", message, ex)
                     raise
 

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -284,7 +284,7 @@ class WebSocketClient:
         except Exception:
             _LOGGER.exception("Unexpected websocket error")
         else:
-            if isinstance(ws.exception(), asyncio.TimeoutError):
+            if isinstance(ws.exception(), TimeoutError):
                 _LOGGER.debug("Websocket Timeout.")
             elif isinstance(ws.exception(), aiohttp.streams.EofStream):
                 _LOGGER.warning("Websocket disconnected unexpectedly. Check network connection.")

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -269,7 +269,7 @@ class WebSocketClient:
         except asyncio.CancelledError:
             self.status = ES_DISCONNECTED
             return
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.debug("Websocket Timeout.")
         except aiohttp.ClientConnectorError as err:
             _LOGGER.error("Websocket Client Connector Error: %s", err)  # noqa: TRY400

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -16,18 +16,23 @@ from .constants import (
     ATTR_VALUE,
     DEFAULT_PRECISION,
     DEFAULT_UNIT_OF_MEASURE,
+    EMPTY_TIME,
     INSTEON_RAMP_RATES,
     ISY_EPOCH_OFFSET,
     ISY_PROP_NOT_SET,
     ISY_VALUE_UNKNOWN,
+    MILITARY_TIME,
     PROP_BATTERY_LEVEL,
     PROP_RAMP_RATE,
     PROP_STATUS,
+    STANDARD_TIME,
     TAG_CATEGORY,
     TAG_GENERIC,
     TAG_MFG,
     TAG_PROPERTY,
     UOM_SECONDS,
+    XML_STRPTIME,
+    XML_STRPTIME_YY,
 )
 from .exceptions import XML_ERRORS
 from .logging import _LOGGER
@@ -134,7 +139,7 @@ def value_from_nested_xml(base: minidom.Element, chain, default: object | None =
     return value
 
 
-def ntp_to_system_time(timestamp):
+def ntp_to_system_time(timestamp: int) -> datetime.datetime:
     """Convert a ISY NTP time to system UTC time.
 
     Adapted from Python ntplib module.
@@ -154,6 +159,24 @@ def ntp_to_system_time(timestamp):
     ntp_delta = ((_system_epoch - _ntp_epoch).days * 24 * 3600) - ISY_EPOCH_OFFSET
 
     return datetime.datetime.fromtimestamp(timestamp - ntp_delta)
+
+
+def parse_isy_datetime(dt_str: str) -> datetime.datetime:
+    """Parse an ISY datetime string, returning EMPTY_TIME on failure."""
+    if not dt_str or not isinstance(dt_str, str):
+        return EMPTY_TIME
+
+    for fmt in (MILITARY_TIME, STANDARD_TIME, XML_STRPTIME, XML_STRPTIME_YY):
+        try:
+            return datetime.datetime.strptime(dt_str, fmt)
+        except ValueError:
+            continue
+
+    try:
+        return datetime.datetime.fromisoformat(dt_str)
+    except ValueError:
+        _LOGGER.debug("Could not parse ISY datetime: %s", dt_str)
+        return EMPTY_TIME
 
 
 def now() -> datetime.datetime:

--- a/pyisy/helpers.py
+++ b/pyisy/helpers.py
@@ -166,6 +166,10 @@ def parse_isy_datetime(dt_str: str) -> datetime.datetime:
     if not dt_str or not isinstance(dt_str, str):
         return EMPTY_TIME
 
+    # The ISY emits trailing whitespace on some datetime fields (e.g. program
+    # last-run/last-finished), which strptime rejects.
+    dt_str = dt_str.strip()
+
     for fmt in (MILITARY_TIME, STANDARD_TIME, XML_STRPTIME, XML_STRPTIME_YY):
         try:
             return datetime.datetime.strptime(dt_str, fmt)

--- a/pyisy/logging.py
+++ b/pyisy/logging.py
@@ -54,6 +54,4 @@ def enable_logging(
         _LOGGER.addHandler(logging.NullHandler())
 
     # Suppress overly verbose logs from libraries that aren't helpful
-    logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("aiohttp.access").setLevel(logging.WARNING)

--- a/pyisy/node_servers.py
+++ b/pyisy/node_servers.py
@@ -156,7 +156,7 @@ class NodeServers:
             self.isy.conn.request(self.isy.conn.compile_url([URL_PROFILE_NS, file])) for file in file_list
         ]
         file_contents: list[str] = await asyncio.gather(*file_tasks)
-        self._profiles: dict[str, str] = dict(zip(file_list, file_contents))
+        self._profiles: dict[str, str] = dict(zip(file_list, file_contents, strict=False))
 
         _LOGGER.info("ISY downloaded node server files")
 

--- a/pyisy/node_servers.py
+++ b/pyisy/node_servers.py
@@ -156,7 +156,7 @@ class NodeServers:
             self.isy.conn.request(self.isy.conn.compile_url([URL_PROFILE_NS, file])) for file in file_list
         ]
         file_contents: list[str] = await asyncio.gather(*file_tasks)
-        self._profiles: dict[str, str] = dict(zip(file_list, file_contents, strict=False))
+        self._profiles: dict[str, str] = dict(zip(file_list, file_contents, strict=True))
 
         _LOGGER.info("ISY downloaded node server files")
 

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -7,8 +7,6 @@ from operator import itemgetter
 from typing import TYPE_CHECKING
 from xml.dom import minidom
 
-from dateutil import parser
-
 from ..constants import (
     ATTR_ID,
     ATTR_PARENT,
@@ -28,7 +26,7 @@ from ..constants import (
     XML_TRUE,
 )
 from ..exceptions import XML_ERRORS, XML_PARSE_ERROR
-from ..helpers import attr_from_element, now, value_from_xml
+from ..helpers import attr_from_element, now, parse_isy_datetime, value_from_xml
 from ..logging import _LOGGER
 from ..nodes import NodeIterator as ProgramIterator
 from .folder import Folder
@@ -185,10 +183,10 @@ class Programs:
                 pobj.ran_else += 1
 
         if f"<{TAG_PRGM_RUN}>" in xml:
-            pobj.last_run = parser.parse(value_from_xml(xmldoc, TAG_PRGM_RUN))
+            pobj.last_run = parse_isy_datetime(value_from_xml(xmldoc, TAG_PRGM_RUN))
 
         if f"<{TAG_PRGM_FINISH}>" in xml:
-            pobj.last_finished = parser.parse(value_from_xml(xmldoc, TAG_PRGM_FINISH))
+            pobj.last_finished = parse_isy_datetime(value_from_xml(xmldoc, TAG_PRGM_FINISH))
 
         if XML_ON in xml or XML_OFF in xml:
             pobj.enabled = XML_ON in xml
@@ -240,12 +238,12 @@ class Programs:
                 # last run time
                 plastrun = value_from_xml(feature, "lastRunTime", EMPTY_TIME)
                 if plastrun != EMPTY_TIME:
-                    plastrun = parser.parse(plastrun)
+                    plastrun = parse_isy_datetime(plastrun)
 
                 # last finish time
                 plastfin = value_from_xml(feature, "lastFinishTime", EMPTY_TIME)
                 if plastfin != EMPTY_TIME:
-                    plastfin = parser.parse(plastfin)
+                    plastfin = parse_isy_datetime(plastfin)
 
                 # enabled, run at startup, running
                 penabled = bool(attr_from_element(feature, TAG_ENABLED) == XML_TRUE)

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -6,8 +6,6 @@ from asyncio import sleep
 from typing import TYPE_CHECKING
 from xml.dom import minidom
 
-from dateutil import parser
-
 from ..constants import (
     ATTR_ID,
     ATTR_INIT,
@@ -20,7 +18,7 @@ from ..constants import (
     TAG_VARIABLE,
 )
 from ..exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
-from ..helpers import attr_from_element, attr_from_xml, now, value_from_xml
+from ..helpers import attr_from_element, attr_from_xml, now, parse_isy_datetime, value_from_xml
 from ..logging import _LOGGER
 from .variable import Variable
 
@@ -139,7 +137,7 @@ class Variables:
             prec = int(value_from_xml(feature, ATTR_PRECISION, 0))
             val = value_from_xml(feature, ATTR_VAL)
             ts_raw = value_from_xml(feature, ATTR_TS)
-            timestamp = parser.parse(ts_raw)
+            timestamp = parse_isy_datetime(ts_raw)
             vname = self.vnames[vtype].get(vid, "")
 
             vobj = self.vobjs[vtype].get(vid)
@@ -184,7 +182,7 @@ class Variables:
         else:
             vobj.status = int(value_from_xml(xmldoc, ATTR_VAL))
             vobj.prec = int(value_from_xml(xmldoc, ATTR_PRECISION, 0))
-            vobj.last_edited = parser.parse(value_from_xml(xmldoc, ATTR_TS))
+            vobj.last_edited = parse_isy_datetime(value_from_xml(xmldoc, ATTR_TS))
 
         _LOGGER.debug("ISY Updated Variable: %s.%s", str(vtype), str(vid))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,10 @@ classifiers=[
     "Topic :: Home Automation",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 dependencies = [
     "aiohttp>=3.8.1",
-    "python-dateutil>=2.8.1",
-    "requests>=2.28.1",
     "colorlog>=6.6.0",
 ]
 
@@ -41,7 +39,7 @@ dependencies = [
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py311"
 line-length = 110
 
 [tool.ruff.lint]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 aiohttp>=3.8.1
-python-dateutil>=2.8.1
-requests>=2.28.1
 colorlog>=6.6.0

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "aiohttp>=3.8.1",
-        "python-dateutil>=2.8.1",
-        "requests>=2.28.1",
         "colorlog>=6.6.0",
     ],
     keywords=["home automation", "isy", "isy994", "isy-994", "UDI"],


### PR DESCRIPTION
## Summary

Bumps the supported Python baseline to 3.11 and removes two install-time
dependencies (`requests`, `python-dateutil`) that the runtime no longer
uses. Splits the work into two commits so the dep removal is reviewable
on its own.

### Commit 1 — `chore: bump baseline to python 3.11 and remove obsolete dependencies`

- Drops `python-dateutil` and `requests` from `install_requires` in both
  `pyproject.toml` and `setup.py`, and from `requirements.txt`.
- Sets `requires-python = ">=3.11"` and `[tool.ruff].target-version = "py311"`.
- Removes the `requests` / `urllib3` logger silencers in `pyisy/logging`,
  since neither library is imported anymore.

### Commit 2 — `refactor: replace dateutil parser with internal helper`

- Adds `helpers.parse_isy_datetime()`, which tries each of the formats
  the ISY is known to emit (`MILITARY_TIME`, `STANDARD_TIME`,
  `XML_STRPTIME`, `XML_STRPTIME_YY`) and falls back to ISO 8601, then to
  `EMPTY_TIME` on failure.
- Swaps the four `dateutil.parser.parse(...)` call sites in
  `pyisy/programs/__init__.py` and `pyisy/variables/__init__.py` over to
  the new helper, and removes the `from dateutil import parser` imports.
- Annotates `ntp_to_system_time(timestamp: int) -> datetime.datetime`
  (no behavior change).

Three small fall-out items from the 3.11 baseline are bundled into this
commit since they're tightly coupled to the dep cleanup:

- `pyisy/connection.py` and `pyisy/events/websocket.py`: catch the
  unified `TimeoutError` rather than the deprecated
  `asyncio.TimeoutError` alias.
- `pyisy/node_servers.py`: pass `strict=True` to `zip()` to silence the
  `B905` lint and add a runtime check on the gather/file_list length
  invariant.
- `docs/quickstart.rst`: replace the `async_timeout.timeout(...)`
  example with the stdlib `asyncio.timeout(...)` form.
- `docs/conf.py` and `docs/index.rst`: drop the `dateutil` and
  `requests` references that are no longer accurate.

### Commit 3 — `fix: address review feedback on baseline modernization`

- Picks up a missed `isinstance(ws.exception(), asyncio.TimeoutError)`
  in `events/websocket.py`.
- Switches the `node_servers.py` zip to `strict=True` per review.

### Out of scope (deliberately not included)

- **`now()` / `ntp_to_system_time` UTC semantics** — moving these from
  naive-local to UTC-anchored was suggested in review, and is a
  reasonable correction, but it shifts every `last_changed` /
  `last_update` / `last_edited` value by the local UTC offset for
  consumers that still treat them as wall-clock. That belongs in its own
  PR with a CHANGELOG entry.


## Test plan

- [x] `pre-commit run --all-files` passes.
- [x] Smoke test against a live eisy via `python3 -m pyisy ...` once a
      reviewer requests it.