### PR TITLE
fix(__main__): await Event instance; drop unmaintained IntelliCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
     "vscode": {
       "extensions": [
         "ms-python.vscode-pylance",
-        "visualstudioexptteam.vscodeintellicode",
         "esbenp.prettier-vscode",
         "github.vscode-pull-request-github",
         "streetsidesoftware.code-spell-checker",

--- a/pyisy/__main__.py
+++ b/pyisy/__main__.py
@@ -93,7 +93,7 @@ async def main(url, username, password, tls_ver, events, node_servers):
             isy.websocket.start()
             node_changed_subscriber = isy.nodes.status_events.subscribe(node_changed_handler)
             system_status_subscriber = isy.status_events.subscribe(system_status_handler)
-        await asyncio.Event.wait()
+        await asyncio.Event().wait()
     except asyncio.CancelledError:
         pass
     finally:


### PR DESCRIPTION
## Summary

- **`pyisy/__main__.py`** — `await asyncio.Event.wait()` is the unbound classmethod call, so the smoke-test entry point dies with `TypeError: Event.wait() missing 1 required positional argument: 'self'` as soon as the connection is up. This is a regression from #408 (ruff ASYNC110), which converted a `while True: await asyncio.sleep(0)` loop to `Event.wait()` without ever instantiating the Event. Fix by constructing the Event first so the await blocks until cancellation.
- **`.devcontainer/devcontainer.json`** — drop the unmaintained `visualstudioexptteam.vscodeintellicode` extension recommendation. Pylance now ships its own completion model and IntelliCode is no longer maintained for this toolchain.

## Test plan

- [x] `python3 -m pyisy http://<eisy>:8080 <user> <pass>` reaches the event-wait point and stays connected (previously crashed immediately).
- [x] `pre-commit run --files pyisy/__main__.py .devcontainer/devcontainer.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)