### PR TITLE
fix: raise ISYResponseParseError on partial / missing setup data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Each platform module is a dict-like collection that owns its entities and expose
 - **UOM/precision sentinel**: `ISY_PROP_NOT_SET = "-1"` distinguishes "node has no ST property" from `ISY_VALUE_UNKNOWN` ("status not yet reported"). Don't conflate them — see CHANGELOG v2.1.0 #98.
 - **XML decoding**: always go through `Connection.request()` so the UTF-8-with-ignore decode is applied. Don't read aiohttp responses directly.
 - **Ruff ignores in `pyproject.toml`** are deliberate (e.g. `S101`, `SLF001`, `PLR091*`); don't try to fix what's listed there as part of unrelated work.
+- **`ISYResponseParseError` is the canonical "controller returned bad/missing data" signal.** Every `parse()` method raises it on `XML_ERRORS`, and `ISY.initialize()` raises it when load-bearing setup responses (status, time, nodes, programs) are `None` so HA Core can convert that into `ConfigEntryNotReady` and retry instead of silently mounting an empty controller (see #297).
 
 ## Branches
 

--- a/pyisy/isy.py
+++ b/pyisy/isy.py
@@ -29,6 +29,7 @@ from .constants import (
 )
 from .events.tcpsocket import EventStream
 from .events.websocket import WebSocketClient
+from .exceptions import ISYResponseParseError
 from .helpers import EventEmitter, value_from_xml
 from .logging import _LOGGER, enable_logging
 from .networking import NetworkResources
@@ -145,6 +146,14 @@ class ISY:
         if self.configuration[CONFIG_NETWORKING] or self.configuration.get(CONFIG_PORTAL):
             isy_setup_tasks.append(asyncio.create_task(self.conn.get_network()))
         isy_setup_results = await asyncio.gather(*isy_setup_tasks)
+
+        # Fail fast if the controller didn't return any of the load-bearing
+        # responses — most often because the ISY is still booting. Mounting
+        # empty managers silently leads to confused downstream consumers.
+        if any(isy_setup_results[i] is None for i in (0, 1, 2, 3)):
+            raise ISYResponseParseError(
+                "ISY did not return all setup data; the controller may still be initializing."
+            )
 
         self.clock = Clock(self, xml=isy_setup_results[1])
         self.nodes = Nodes(self, xml=isy_setup_results[2])

--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -14,7 +14,7 @@ from .constants import (
     URL_NETWORK,
     URL_RESOURCES,
 )
-from .exceptions import XML_ERRORS, XML_PARSE_ERROR
+from .exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
 from .helpers import value_from_xml
 from .logging import _LOGGER
 
@@ -72,9 +72,9 @@ class NetworkResources:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except XML_ERRORS:
+        except XML_ERRORS as exc:
             _LOGGER.error("%s: NetworkResources, resources not loaded", XML_PARSE_ERROR)
-            return
+            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
 
         features = xmldoc.getElementsByTagName(TAG_NET_RULE)
         for feature in features:

--- a/pyisy/networking.py
+++ b/pyisy/networking.py
@@ -73,8 +73,7 @@ class NetworkResources:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: NetworkResources, resources not loaded", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: NetworkResources") from exc
 
         features = xmldoc.getElementsByTagName(TAG_NET_RULE)
         for feature in features:

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -25,7 +25,7 @@ from ..constants import (
     XML_ON,
     XML_TRUE,
 )
-from ..exceptions import XML_ERRORS, XML_PARSE_ERROR
+from ..exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
 from ..helpers import attr_from_element, now, parse_isy_datetime, value_from_xml
 from ..logging import _LOGGER
 from ..nodes import NodeIterator as ProgramIterator
@@ -208,9 +208,9 @@ class Programs:
         """
         try:
             xmldoc = minidom.parseString(xml)
-        except XML_ERRORS:
+        except XML_ERRORS as exc:
             _LOGGER.error("%s: Programs, programs not loaded", XML_PARSE_ERROR)
-            return
+            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
 
         plastup = now()
 

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -209,8 +209,7 @@ class Programs:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Programs, programs not loaded", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Programs") from exc
 
         plastup = now()
 


### PR DESCRIPTION
## Summary

When the ISY is still booting it returns malformed XML or empty responses to the parallel setup REST calls fired by `ISY.initialize()`. Previously two of the parsers (`Programs`, `NetworkResources`) silently swallowed the error and returned, and `request()`-exhausted `None` results fell through the per-manager `if xml is not None` guards — so we mounted an empty controller and let the consumer crash later (see #297, where HA's `_categorize_programs` hit `len(None)` deep in `get_by_name`).

## Changes

- Bring the `Programs` and `NetworkResources` parsers in line with `Nodes`/`Variables`/`Clock`/`Configuration` — raise `ISYResponseParseError` from `XML_ERRORS` instead of swallowing.
- Have `ISY.initialize()` fail fast when `status`, `time`, `nodes`, or `programs` come back `None`. HA Core's `async_setup_entry` can convert that into `ConfigEntryNotReady` and retry instead of completing setup with a half-loaded controller.

## Intentionally NOT in the fail-fast set

- `networking` — per #457, `get_network()` returning `None` for a missing `RES.CFG` is a normal capability state on eisy units without the networking module enabled, not a fatal startup signal.

Closes #297.

## Test plan

- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)