### PR TITLE
cleanup: drop redundant _LOGGER.error before raise

### DIFF
--- a/pyisy/clock.py
+++ b/pyisy/clock.py
@@ -85,8 +85,7 @@ class Clock:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Clock", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Clock") from exc
 
         tz_offset_sec = int(value_from_xml(xmldoc, TAG_TZ_OFFSET))
         self._tz_offset = tz_offset_sec / 3600

--- a/pyisy/configuration.py
+++ b/pyisy/configuration.py
@@ -88,8 +88,7 @@ class Configuration(dict):
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Configuration", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Configuration") from exc
 
         self["firmware"] = value_from_xml(xmldoc, TAG_FIRMWARE)
         self["uuid"] = value_from_nested_xml(xmldoc, [TAG_ROOT, ATTR_ID])

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -96,8 +96,7 @@ class Connection:
         """Test the connection and get the config for the ISY."""
         config = await self.get_config(retries=None)
         if not config:
-            _LOGGER.error("Could not connect to the ISY with the parameters provided.")
-            raise ISYConnectionError
+            raise ISYConnectionError("Could not connect to the ISY with the parameters provided.")
         return config
 
     def increase_available_connections(self) -> None:
@@ -197,7 +196,6 @@ class Connection:
                         res.release()
                         return None
                 if res.status == HTTP_UNAUTHORIZED:
-                    _LOGGER.error("Invalid credentials provided for ISY connection.")
                     res.release()
                     raise ISYInvalidAuthError("Invalid credentials provided for ISY connection.")
                 if res.status == HTTP_SERVICE_UNAVAILABLE:

--- a/pyisy/node_servers.py
+++ b/pyisy/node_servers.py
@@ -100,8 +100,7 @@ class NodeServers:
         try:
             connections_xml = minidom.parseString(result)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s while parsing Node Server connections", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Node Server connections") from exc
 
         connections = connections_xml.getElementsByTagName(TAG_CONNECTION)
         for connection in connections:
@@ -136,8 +135,7 @@ class NodeServers:
         try:
             file_list_xml = minidom.parseString(node_server_file_list)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s while parsing Node Server files", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Node Server files") from exc
 
         file_list: list[str] = []
 

--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -363,8 +363,7 @@ class Nodes:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Nodes", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Nodes") from exc
 
         # get nodes
         ntypes = [TAG_FOLDER, TAG_NODE, TAG_GROUP]

--- a/pyisy/nodes/node.py
+++ b/pyisy/nodes/node.py
@@ -298,8 +298,7 @@ class Node(NodeBase):
         try:
             parameter_dom = minidom.parseString(parameter_xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Node Parameter %s", XML_PARSE_ERROR, parameter_xml)
-            raise ISYResponseParseError from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Node Parameter {parameter_xml}") from exc
 
         size = int(attr_from_xml(parameter_dom, TAG_CONFIG, TAG_SIZE))
         value = attr_from_xml(parameter_dom, TAG_CONFIG, TAG_VALUE)
@@ -449,8 +448,7 @@ class Node(NodeBase):
             try:
                 xmldoc = minidom.parseString(xml)
             except XML_ERRORS as exc:
-                _LOGGER.error("%s: Nodes", XML_PARSE_ERROR)
-                raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+                raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Nodes") from exc
 
         if xmldoc is None:
             _LOGGER.warning("ISY could not update node: %s", self._id)

--- a/pyisy/nodes/nodebase.py
+++ b/pyisy/nodes/nodebase.py
@@ -198,8 +198,7 @@ class NodeBase:
             try:
                 notes_dom = minidom.parseString(notes_xml)
             except XML_ERRORS as exc:
-                _LOGGER.error("%s: Node Notes %s", XML_PARSE_ERROR, notes_xml)
-                raise ISYResponseParseError from exc
+                raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Node Notes {notes_xml}") from exc
 
             spoken = value_from_xml(notes_dom, TAG_SPOKEN)
             location = value_from_xml(notes_dom, TAG_LOCATION)

--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -126,8 +126,7 @@ class Variables:
         try:
             xmldoc = minidom.parseString(xml)
         except XML_ERRORS as exc:
-            _LOGGER.error("%s: Variables", XML_PARSE_ERROR)
-            raise ISYResponseParseError(XML_PARSE_ERROR) from exc
+            raise ISYResponseParseError(f"{XML_PARSE_ERROR}: Variables") from exc
 
         features = xmldoc.getElementsByTagName(ATTR_VAR)
         for feature in features:


### PR DESCRIPTION
## Summary

Follow-up to #481, which flagged that `_LOGGER.error(...)` immediately before `raise ...` is a double-logging anti-pattern. PR #481 fixed it for the two parsers it touched (`Programs`, `NetworkResources`); this PR applies the same cleanup to the remaining sites across the codebase.

Why this is an anti-pattern:
- The standalone ERROR log lacks a traceback.
- The caller (or HA's setup pipeline) logs the propagated exception with full context anyway, so users see two log entries for one failure.
- When the caller intentionally catches it (e.g., HA `ConfigEntryNotReady` retry), the standalone ERROR is visible noise for what's actually a recoverable condition.

## Sites cleaned up

**XML parsers** (`ISYResponseParseError` raise sites):
- `clock.py` — Clock parse
- `configuration.py` — Configuration parse
- `variables/__init__.py` — Variables parse
- `node_servers.py` — Node Server connections + profile-files parse (2 sites)
- `nodes/__init__.py` — Nodes parse
- `nodes/node.py` — single-node status parse
- `nodes/nodebase.py` — Node Notes parse

**Connection layer** (`connection.py`):
- `Connection.test_connection()` — `ISYConnectionError`. The standalone log carried the only context; folded the message into the exception arg.
- `Connection.request()` HTTP 401 branch — `ISYInvalidAuthError`. The log message was duplicated verbatim into the raise; dropped the log line.

Each `raise` now embeds the parser/site location in the exception message (e.g. `f"{XML_PARSE_ERROR}: Clock"`) so the source is still visible in the traceback. No call sites change; exception types and `__cause__` chains are identical.

## Intentionally not touched

- `node_servers.py` line 179 (`_LOGGER.error` inside `parse_node_server_defs`) — that one `continue`s instead of raising, so it's the legitimate "log and skip" pattern, not the anti-pattern.
- `Connection.request()` `TimeoutError`, `ClientOSError`, `ServerDisconnectedError`, `ClientError`, and the `ClientResponseError` branch that conditionally returns `None` — those log-without-raise (or log-then-return) handlers are not the double-report anti-pattern this PR targets.

## Test plan

- [x] `pre-commit run` passes on all touched files
- [x] All affected modules import cleanly in the devcontainer
- [x] No behavioral change expected; covered by existing `ISY.initialize()` startup smoke against a real ISY

🤖 Generated with [Claude Code](https://claude.com/claude-code)