### PR TITLE
fix: avoid IndexError in Connection.request for non-/rest URLs

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -170,7 +170,10 @@ class Connection:
                     ssl=self.sslcontext,
                 ) as res,
             ):
-                endpoint = url.split("rest", 1)[1]
+                # /desc and other non-/rest URLs lack the "rest" substring.
+                _, _, endpoint = url.partition("rest")
+                if not endpoint:
+                    endpoint = url
                 if res.status == HTTP_OK:
                     _LOGGER.debug("ISY Response Received: %s", endpoint)
                     results = await res.text(encoding="utf-8", errors="ignore")


### PR DESCRIPTION
Fixes #488.

`Connection.request()` splits the URL on `"rest"` to compute the debug-log endpoint string and unconditionally indexes `[1]`. `Connection.get_description()` builds a URL that ends in `/desc` and contains no `rest` substring, so `split("rest", 1)[1]` raises `IndexError` on the happy path before the response can be returned.

Switched to `str.partition` with a fallback to the full URL when the separator is absent — preserves the previous endpoint string for `/rest/` URLs and stops the crash for `/desc` (and any future non-`/rest/` endpoint).