### PR TITLE
fix: use DOM lookup for program enable/disable events

### DIFF
--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -21,8 +21,6 @@ from ..constants import (
     TAG_PRGM_STATUS,
     TAG_PROGRAM,
     UPDATE_INTERVAL,
-    XML_OFF,
-    XML_ON,
     XML_TRUE,
 )
 from ..exceptions import XML_ERRORS, XML_PARSE_ERROR, ISYResponseParseError
@@ -188,8 +186,13 @@ class Programs:
         if f"<{TAG_PRGM_FINISH}>" in xml:
             pobj.last_finished = parse_isy_datetime(value_from_xml(xmldoc, TAG_PRGM_FINISH))
 
-        if XML_ON in xml or XML_OFF in xml:
-            pobj.enabled = XML_ON in xml
+        # minidom.toxml() collapses "<on />" to "<on/>", so substring
+        # matching the serialized form against XML_ON/XML_OFF never
+        # fires. Walk the parsed DOM instead (#487).
+        if xmldoc.getElementsByTagName("on"):
+            pobj.enabled = True
+        elif xmldoc.getElementsByTagName("off"):
+            pobj.enabled = False
 
         # Update Status last and make sure the change event fires, but only once.
         if pobj.status != new_status:


### PR DESCRIPTION
Fixes #487.

`Programs.update_received` checks for program enable/disable toggles by substring-matching the constants `XML_ON = "<on />"` / `XML_OFF = "<off />"` against `xmldoc.toxml()`. But `minidom.toxml()` collapses self-closing tags (`<on />` → `<on/>`), so the match never fires and `pobj.enabled` is never updated when the controller sends an enable/disable event.

Switched to `xmldoc.getElementsByTagName("on" / "off")` per option 2 in the issue — robust to minidom's whitespace handling across Python versions and doesn't depend on the constants matching the serialized form. The unused `XML_ON` / `XML_OFF` constants are left in `constants.py` since they're part of the public module surface.

The regression test for this lives in PR #484 (`tests/test_programs_extras.py::test_update_received_on_off_toggle_currently_no_op`) — it currently pins the broken behavior. Once this lands, that PR will flip the assertion to verify `enabled` actually updates.