### PR TITLE
fix: cast Variable._type for protocol comparison

### DIFF
--- a/pyisy/variables/variable.py
+++ b/pyisy/variables/variable.py
@@ -130,7 +130,9 @@ class Variable:
     @property
     def protocol(self) -> str:
         """Return the protocol for this entity."""
-        return PROTO_INT_VAR if self._type == VAR_INTEGER else PROTO_STATE_VAR
+        # Variables.parse() stores _type as int but VAR_INTEGER is the
+        # string "1"; cast for the comparison (#485).
+        return PROTO_INT_VAR if str(self._type) == VAR_INTEGER else PROTO_STATE_VAR
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Fixes #485.

`Variables.parse()` stores `_type` as `int` (`int(attr_from_element(...))`), but `VAR_INTEGER` / `VAR_STATE` in `constants.py` are strings (`"1"` / `"2"`). The equality check in `Variable.protocol` was therefore always False, so every variable reported `PROTO_STATE_VAR` regardless of actual type.

Going with the option 1 fix: cast `self._type` to `str` at the comparison site. The four `compile_url` call sites in `connection.py` rely on the string form (`urllib.parse.quote` requires `str`/`bytes`), and no consumer outside this property compares `_type` to the constants — verified `homeassistant/components/isy994/` doesn't import either name. Option 2 (flip the constants to int + coerce in `compile_url`) is a wider typing cleanup that I'd argue belongs in its own PR.

Regression test sits in PR #484 (`tests/test_variables_extras.py::test_variable_protocol_returns_known_constant`) — it currently asserts only that the result is one of the two known constants. Once this lands, that test will tighten to assert the correct classification per variable type.