### PR TITLE
fix: correct Variables name-based lookup paths

### DIFF
--- a/pyisy/variables/__init__.py
+++ b/pyisy/variables/__init__.py
@@ -201,7 +201,7 @@ class Variables:
             except (ValueError, KeyError) as err:
                 raise KeyError(f"Unrecognized variable id: {val}") from err
 
-        for vid, vname in self.vnames[self.root]:
+        for vid, vname in self.vnames[self.root].items():
             if vname == val:
                 return self.vobjs[self.root][vid]
         raise KeyError(f"Unrecognized variable name: {val}")
@@ -215,11 +215,15 @@ class Variables:
         Get a variable with the given name.
 
         |  val: The name of the variable to look for.
+
+        Returns the first match. Variable names are not guaranteed
+        unique by the controller (see #445), so callers that need a
+        specific instance should look up by ``(type, id)`` instead.
         """
-        vtype, _, vid = next(item for item in self.children if val in item)
-        if not vid and vtype:
-            raise KeyError(f"Unrecognized variable name: {val}")
-        return self.vobjs[vtype].get(vid)
+        for vtype, name, vid in self.children:
+            if name == val:
+                return self.vobjs[vtype].get(vid)
+        return None
 
     @property
     def children(self) -> list[tuple[int, str, int]]:


### PR DESCRIPTION
Fixes #486.

Two name-lookup paths in `Variables` were broken:

- `__getitem__` iterated `self.vnames[root]` (a `dict[int, str]`) and tried to unpack each element as `(vid, vname)`. Iterating a dict yields keys only, so this raised `TypeError: cannot unpack non-iterable int object` on every name-based access.
- `get_by_name` used `val in item` against a 3-tuple, which substring-matches the whole tuple's repr — partial name matches would silently return the wrong variable. `next(...)` with no default also leaked `StopIteration` on no-match.

Switched both to linear scan with name equality, matching the pattern established in #445. The collaborator comment on #486 asked whether #445 applies — yes: variable names aren't guaranteed unique by the controller either, so first-match-wins via linear scan is the correct semantic. `get_by_name` now returns `None` on miss to align with `Nodes.get_by_name` / `NetworkResources.get_by_name`. `__getitem__` continues to raise `KeyError` per the dict protocol.

**HA Core impact**: none. `homeassistant/components/isy994/__init__.py:141` accesses `isy.variables[vtype][vid]` by integer (type, id), never by name.

Regression test sits in PR #484 — once this lands I'll add positive name-lookup coverage to `tests/test_variables_extras.py`.