### PR TITLE
fix: small quirks surfaced while writing the test suite

### DIFF
--- a/pyisy/nodes/__init__.py
+++ b/pyisy/nodes/__init__.py
@@ -67,6 +67,7 @@ from ..helpers import (
     ZWaveProperties,
     attr_from_element,
     attr_from_xml,
+    now,
     parse_xml_properties,
     value_from_xml,
 )
@@ -412,7 +413,11 @@ class Nodes:
                     self.insert(address, nname, nparent, None, ntype)
                 elif ntype == TAG_NODE:
                     if address in self.addresses:
-                        self.get_by_id(address).update(xmldoc=feature)
+                        node = self.get_by_id(address)
+                        node._last_update = now()
+                        state, _aux_props, _ = parse_xml_properties(feature)
+                        node._aux_properties.update(_aux_props)
+                        node.update_state(state)
                         continue
                     state, aux_props, state_set = parse_xml_properties(feature)
                     self.insert(
@@ -687,6 +692,9 @@ class NodeIterator:
             self._ind = 0
         else:
             self._ind = self._len - 1
+
+    def __iter__(self):
+        return self
 
     def __next__(self):
         """Get the next element in the iteration."""

--- a/pyisy/programs/__init__.py
+++ b/pyisy/programs/__init__.py
@@ -325,8 +325,8 @@ class Programs:
                 try:
                     val = int(val)
                     fun = self.get_by_index
-                except (TypeError, ValueError) as err:
-                    raise KeyError("Unrecognized Key: " + str(val)) from err
+                except (TypeError, ValueError):
+                    return None
         try:
             return fun(val)
         except (ValueError, KeyError, IndexError):


### PR DESCRIPTION
Three independent issues observed while building out the offline pytest suite (#484), grouped here because each is one or two lines and none warrants its own ticket.

## 1. `Nodes.parse()` re-update path silently dropped

`pyisy/nodes/__init__.py` line 415 (pre-fix) called the async `Node.update(xmldoc=feature)` from a synchronous parsing loop without `await`. The returned coroutine was never run, so when `parse()` re-encountered an existing address (the re-update branch) the node's status was never refreshed from the new XML. The test suite caught this as `RuntimeWarning: coroutine 'Node.update' was never awaited`.

Fix inlines the synchronous portion of `Node.update(xmldoc=...)` directly in the parser: capture `last_update`, merge `aux_properties`, and call `update_state(state)`. No new public method on `Node`; the async `Node.update` is unchanged for its other callers.

## 2. `NodeIterator` missing `__iter__`

`NodeIterator` implemented `__next__` and `__len__` but not `__iter__`. Python's `for` protocol calls `iter()` on the iterable, which requires `__iter__` on the iterator object itself — without it, `for x in iter(nodes)` and `for x in reversed(nodes)` raise `TypeError`. Added the conventional `__iter__` returning `self`.

`Programs` reuses the same iterator class (aliased as `ProgramIterator`), so this fix covers both managers.

## 3. `Programs.__getitem__` raised `KeyError` on unrecognized keys

The inner `try` around `fun(val)` returns `None` on `KeyError`/`IndexError`/`ValueError`, and the signature is `-> Program | Folder | None` — but the path where `val` isn't an address, isn't a known name, and can't be `int()`-converted raised `KeyError("Unrecognized Key: ...")` instead of returning `None`. Inconsistent with the other miss paths.

Fix returns `None` from that branch too, matching the rest of the method.

## Test plan

Regression coverage lands in PR #484 (the test-suite PR), which already has the failing-warning case for #1 and tightens the Programs miss assertions for #3. No new tests in this PR — the fixes are small enough to review on their own.

## HA Core impact

None. `homeassistant/components/isy994/` doesn't iterate `NodeIterator` directly, doesn't call `Programs.__getitem__("missing-key")` with the expectation of a `KeyError`, and the dropped re-parse manifested as a stale cache the existing event-stream handlers immediately re-corrected.