### PR TITLE
chore: align .vscode with modernized ruff tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ example/
 
 # Output when dumping to file enabled
 .output/*
+
+.venv/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,10 @@
 {
   "recommendations": [
+    "ms-python.vscode-pylance",
     "esbenp.prettier-vscode",
-    "ms-python.python",
-    "ms-python.black-formatter"
+    "github.vscode-pull-request-github",
+    "streetsidesoftware.code-spell-checker",
+    "njpwerner.autodocstring",
+    "charliermarsh.ruff"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,14 @@
 {
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.formatting.provider": "black",
+  "python.testing.pytestArgs": ["--no-cov"],
   "editor.formatOnPaste": false,
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
+  "editor.formatOnSaveMode": "file",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "editor.defaultFormatter": "charliermarsh.ruff",
   "files.trimTrailingWhitespace": true,
-  "python.linting.flake8Enabled": false,
-  "cSpell.words": ["automodule"],
-  "editor.formatOnSaveMode": "file"
+  "cSpell.words": ["automodule", "pyisy"]
 }


### PR DESCRIPTION
## Summary
- Update `.vscode/extensions.json` and `.vscode/settings.json` to match the devcontainer customizations after the move from black/pylint to ruff (#468, #473) — drop `ms-python.python`/`ms-python.black-formatter` and the dead `python.linting.*` / `python.formatting.provider` keys; add `charliermarsh.ruff` as the default formatter with the same `codeActionsOnSave` (fixAll + organizeImports) the devcontainer uses.
- Add `pylance`, `prettier`, `pull-request-github`, `code-spell-checker`, `autodocstring` to the recommended extensions to mirror the devcontainer set.
- Set `python.testing.pytestArgs: ["--no-cov"]` so the editor test runner stays usable once the test suite lands.
- Ignore `.venv/` so local virtualenvs stay out of `git status`.

## Test plan
- [ ] Open the workspace in VS Code outside the devcontainer; verify ruff is the active formatter and "format on save" works.
- [ ] Confirm the recommended-extensions prompt offers the new set on a fresh clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)