### PR TITLE
fix: raise ISYConnectionError on SSL/TLS handshake failures

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -212,6 +212,22 @@ class Connection:
 
         except TimeoutError:
             _LOGGER.warning("Timeout while trying to connect to the ISY.")
+        except aiohttp.ClientSSLError as err:
+            # SSL/TLS handshake failure. Subclass of ``ClientOSError``, so
+            # the broader branch below would otherwise eat it silently as
+            # a generic "ISY not ready or closed connection." debug.
+            # Almost always one of:
+            #   * controller pinned below the ``tls_ver='auto'`` floor of
+            #     TLS 1.2 (e.g. an ISY-994 manually downgraded to 1.1, or
+            #     a modern OpenSSL distro with ``MinProtocol=TLSv1.2``).
+            #   * ``verify_ssl=True`` against the controller's self-signed
+            #     cert (``ClientConnectorCertificateError``).
+            # Always raise — retrying won't recover from a config
+            # mismatch, and callers (HA Core) need a definitive failure
+            # to translate into ``ConfigEntryNotReady`` rather than a
+            # silent ``None`` that looks like a transient miss. The SSL
+            # detail rides along in the exception chain.
+            raise ISYConnectionError(f"SSL/TLS error: {err}") from err
         except (
             aiohttp.ClientOSError,
             aiohttp.ServerDisconnectedError,

--- a/tests/test_connection_extras.py
+++ b/tests/test_connection_extras.py
@@ -298,6 +298,60 @@ async def test_request_client_response_error_with_ok404_returns_empty(
     assert result == ""
 
 
+async def test_request_ssl_error_always_raises_connection_error(
+    conn: Connection,
+) -> None:
+    """SSL/TLS handshake failures are non-recoverable config mismatches
+    (controller pinned below auto-floor TLS 1.2, or ``verify_ssl=True``
+    against a self-signed cert). ``request`` must raise
+    ``ISYConnectionError`` rather than logging + returning ``None``,
+    even on the retry path — retrying a handshake that failed for a
+    protocol/cert reason won't help, and callers (HA Core) need a
+    definitive failure to translate into ``ConfigEntryNotReady``
+    instead of treating it as a transient miss.
+
+    The raise replaces the previous opaque
+    ``ClientOSError`` → DEBUG "ISY not ready or closed connection."
+    branch that silently ate ``ClientConnectorSSLError`` (a subclass).
+    The SSL detail rides along in ``__cause__`` and the exception
+    message — no separate WARNING/ERROR log so we don't double up."""
+    from unittest.mock import MagicMock
+
+    from pyisy.exceptions import ISYConnectionError
+
+    url = conn.compile_url(["status"])
+    ssl_err = aiohttp.ClientConnectorSSLError(
+        MagicMock(),
+        ssl.SSLError(1, "[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol"),
+    )
+    with aioresponses() as mocked:
+        mocked.get(url, exception=ssl_err)
+        with pytest.raises(ISYConnectionError, match="SSL/TLS error") as excinfo:
+            await conn.request(url)
+    # Cause chain preserves the original aiohttp SSL error for
+    # callers / log handlers that want to introspect it.
+    assert isinstance(excinfo.value.__cause__, aiohttp.ClientSSLError)
+
+
+async def test_request_ssl_error_raises_on_test_connection_path(
+    conn: Connection,
+) -> None:
+    """Same behavior on the ``retries=None`` path used by
+    ``test_connection`` / ``ISY.initialize`` — verifying the SSL branch
+    is taken before the (formerly raise-on-retries-None) generic
+    ``ClientOSError`` branch."""
+    from unittest.mock import MagicMock
+
+    from pyisy.exceptions import ISYConnectionError
+
+    url = conn.compile_url(["config"])
+    ssl_err = aiohttp.ClientConnectorSSLError(MagicMock(), ssl.SSLError(1, "unsupported protocol"))
+    with aioresponses() as mocked:
+        mocked.get(url, exception=ssl_err)
+        with pytest.raises(ISYConnectionError, match="SSL/TLS error"):
+            await conn.request(url, retries=None)
+
+
 async def test_request_non_rest_url_does_not_crash(conn: Connection) -> None:
     """Regression for #488: ``request()`` derives its debug-log endpoint
     from the URL by splitting on ``"rest"``. ``get_description()`` builds


### PR DESCRIPTION
## Summary

`aiohttp.ClientConnectorSSLError` is a subclass of `ClientOSError`, so the existing catch-all branch silently classified TLS handshake failures as a generic `DEBUG ISY not ready or closed connection.` — and on the retry path returned a silent `None` that looks indistinguishable from a transient miss.

This PR catches `aiohttp.ClientSSLError` (covers both `ClientConnectorSSLError` and `ClientConnectorCertificateError`) before the generic `ClientOSError` branch and always raises `ISYConnectionError` with the SSL detail in the message. The original aiohttp error rides along in `__cause__`. No separate WARNING/ERROR log — the failure surfaces exactly once.

## Why always raise (not just on `retries=None`)

An SSL handshake failure isn't a transient network blip — it's a config mismatch:
- Controller pinned below the `tls_ver='auto'` floor of TLS 1.2 (e.g. ISY-994 manually downgraded to TLS 1.1, or modern OpenSSL with `MinProtocol=TLSv1.2`)
- `verify_ssl=True` against the controller's self-signed cert (`ClientConnectorCertificateError`)

Neither recovers from retry. Callers (HA Core) need a definitive failure to translate into `ConfigEntryNotReady`, not silent retries.

## Before / after (ISY-994 at TLS 1.1, modern OpenSSL host)

Before — silent debug, then a generic wrapper error from `test_connection`:
```
DEBUG ISY not ready or closed connection.
ISYConnectionError: Could not connect to the ISY with the parameters provided.
```

After — raises directly with SSL context, original cause preserved:
```
ISYConnectionError: SSL/TLS error: Cannot connect to host 192.168.30.186:443 ssl:<...> [[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol]
  ↑ __cause__: aiohttp.ClientConnectorSSLError
  ↑ __cause__: ssl.SSLError: [SSL: UNSUPPORTED_PROTOCOL] unsupported protocol
```

## Test plan

- [x] `pytest -q` (438 passed)
- [x] Pre-commit clean
- [x] Smoke-tested against an ISY-994 manually downgraded to TLS 1.1 with `MinProtocol=TLSv1.2` on the host
- [x] New regression tests:
  - `test_request_ssl_error_always_raises_connection_error` — covers retry path
  - `test_request_ssl_error_raises_on_test_connection_path` — covers `retries=None` init path
  - Both assert `__cause__` carries the original `ClientSSLError`

## Compatibility note

`ISYConnectionError` is the same exception type that was raised previously on the `retries=None` (init) path — so the `ISY.initialize()` contract is unchanged, just with a more specific message. The behavioral shift is for non-init `request()` calls that previously returned `None` on SSL failure: those now raise. In practice that path is reached only if a long-lived session sees its TLS context become invalid mid-flight (cert rotation, etc.), which warrants a definitive failure rather than a silent retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)