### PR TITLE
fix: exclude tests/ from built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description="Python module to talk to ISY994 from UDI.",
     long_description=README,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=False,
     include_package_data=True,
     platforms="any",


### PR DESCRIPTION
## Summary

The 3.6.0 wheel ships a top-level `tests` package because `setup.py` calls `find_packages()` without exclusions. This breaks downstream consumers that have their own `tests/` directory — most notably Home Assistant Core, where hassfest fails:

```
[ERROR] [REQUIREMENTS] Package pyisy has a forbidden top level directory 'tests' in homeassistant
```

Adding `exclude=["tests", "tests.*"]` keeps the source tree shape but limits the wheel to the `pyisy` package.

## Verification

```
$ python -m build --wheel
$ python -m zipfile -l dist/pyisy-*.whl | awk '{print $1}' | grep -c "^tests"
0
```

## Follow-up

A 3.6.1 release is needed to unblock home-assistant/core#170136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)