### PR TITLE
fix(test): pin aiohttp<3.14 to work around aioresponses incompatibility

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,8 @@ pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
 syrupy>=5.5.3
 aioresponses>=0.7.9
+# aioresponses 0.7.9 (latest release) predates aiohttp 3.14's new required
+# ClientResponse `stream_writer` kwarg -- fix is open upstream but unreleased:
+# https://github.com/pnuckowski/aioresponses/pull/288. Remove this cap once
+# a released aioresponses version picks it up.
+aiohttp<3.14


### PR DESCRIPTION
## Summary
- CI has been red on both the 3.11 and 3.14 test jobs since the runner started picking up aiohttp 3.14, which added a required `stream_writer` kwarg to `ClientResponse.__init__`. `aioresponses` 0.7.9 (latest release) doesn't pass it when building mock responses, so every test that exercises `Connection.request()` through `aioresponses` fails with `TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'` (11 failures).
- Upstream fix is open but unreleased: pnuckowski/aioresponses#288.
- Pinned `aiohttp<3.14` in `requirements-test.txt` only — this doesn't touch the library's own `aiohttp>=3.8.1` floor in `pyproject.toml`/`requirements.txt`, so it has no effect on downstream consumers (e.g. Home Assistant Core, which currently pins `aiohttp==3.13.5` anyway).
- Left the `aiohttp.BasicAuth` deprecation warning (also present in the logs) as-is for now — fixing it properly means switching to `aiohttp.encode_basic_auth()`, which requires bumping the floor to `aiohttp>=3.14.0`. That would make PyISY's requirements incompatible with HA Core's current `aiohttp==3.13.5` pin, so it's out of scope here.

## Test plan
- [x] `pytest` — 448 passed locally with `aiohttp==3.13.5` installed
- [x] `pre-commit run --all-files` — clean
- [x] CI green on both Python 3.11 and 3.14 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPpQYEKnQFCiy3GS3D2fKs