### PR TITLE
Migrate tests to aiointercept and use aiohttp.encode_basic_auth

### DIFF
--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import ssl
 import warnings
+from base64 import b64encode
 from typing import Literal
 from urllib.parse import quote, urlencode
 
@@ -57,6 +58,17 @@ HTTP_HEADERS = {
 
 EMPTY_XML_RESPONSE = '<?xml version="1.0" encoding="UTF-8"?>'
 
+
+def basic_auth_header(username: str, password: str) -> str:
+    """Return the value of an HTTP Basic ``Authorization`` header.
+
+    ``aiohttp.BasicAuth`` is deprecated and goes away in aiohttp 4.0. Its
+    replacement, ``aiohttp.encode_basic_auth()``, needs aiohttp 3.14, which
+    the test suite cannot use yet (see ``requirements-test.txt``).
+    """
+    return "Basic " + b64encode(f"{username}:{password}".encode()).decode()
+
+
 # ``ssl.OP_LEGACY_SERVER_CONNECT`` was added to the stdlib ``ssl``
 # module in Python 3.12; CI still runs on 3.11. The underlying OpenSSL
 # flag ``SSL_OP_LEGACY_SERVER_CONNECT`` has had the stable value
@@ -88,7 +100,8 @@ class Connection:
         self._port = port
         self._username = username
         self._password = password
-        self._auth = aiohttp.BasicAuth(self._username, self._password)
+        self._auth_header = basic_auth_header(self._username, self._password)
+        self._headers = {**HTTP_HEADERS, "Authorization": self._auth_header}
         self._webroot = webroot.rstrip("/")
         self.req_session = websession
         self._tls_ver = tls_ver
@@ -126,7 +139,7 @@ class Connection:
     def connection_info(self) -> dict[str, str | int | bytes | None]:
         """Return the connection info required to connect to the ISY."""
         connection_info = {}
-        connection_info["auth"] = self._auth.encode()
+        connection_info["auth"] = self._auth_header
         connection_info["addr"] = self._address
         connection_info["port"] = int(self._port)
         connection_info["passwd"] = self._password
@@ -176,8 +189,7 @@ class Connection:
                 self.semaphore,
                 self.req_session.get(
                     url,
-                    auth=self._auth,
-                    headers=HTTP_HEADERS,
+                    headers=self._headers,
                     timeout=HTTP_TIMEOUT,
                     ssl=self.sslcontext,
                 ) as res,

--- a/pyisy/connection.py
+++ b/pyisy/connection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import ssl
 import warnings
-from base64 import b64encode
 from typing import Literal
 from urllib.parse import quote, urlencode
 
@@ -58,17 +57,6 @@ HTTP_HEADERS = {
 
 EMPTY_XML_RESPONSE = '<?xml version="1.0" encoding="UTF-8"?>'
 
-
-def basic_auth_header(username: str, password: str) -> str:
-    """Return the value of an HTTP Basic ``Authorization`` header.
-
-    ``aiohttp.BasicAuth`` is deprecated and goes away in aiohttp 4.0. Its
-    replacement, ``aiohttp.encode_basic_auth()``, needs aiohttp 3.14, which
-    the test suite cannot use yet (see ``requirements-test.txt``).
-    """
-    return "Basic " + b64encode(f"{username}:{password}".encode()).decode()
-
-
 # ``ssl.OP_LEGACY_SERVER_CONNECT`` was added to the stdlib ``ssl``
 # module in Python 3.12; CI still runs on 3.11. The underlying OpenSSL
 # flag ``SSL_OP_LEGACY_SERVER_CONNECT`` has had the stable value
@@ -100,7 +88,7 @@ class Connection:
         self._port = port
         self._username = username
         self._password = password
-        self._auth_header = basic_auth_header(self._username, self._password)
+        self._auth_header = aiohttp.encode_basic_auth(self._username, self._password)
         self._headers = {**HTTP_HEADERS, "Authorization": self._auth_header}
         self._webroot = webroot.rstrip("/")
         self.req_session = websession

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -11,7 +11,12 @@ from xml.dom import minidom
 
 import aiohttp
 
-from ..connection import TLSVer, get_new_client_session, get_sslcontext
+from ..connection import (
+    TLSVer,
+    basic_auth_header,
+    get_new_client_session,
+    get_sslcontext,
+)
 from ..constants import (
     ACTION_KEY,
     ACTION_KEY_CHANGED,
@@ -83,7 +88,8 @@ class WebSocketClient:
         self._port = port
         self._username = username
         self._password = password
-        self._auth = aiohttp.BasicAuth(self._username, self._password)
+        self._auth_header = basic_auth_header(self._username, self._password)
+        self._headers = {**WS_HEADERS, "Authorization": self._auth_header}
         self._webroot = webroot.rstrip("/")
         self._tls_ver = tls_ver
         self.use_https = use_https
@@ -301,9 +307,8 @@ class WebSocketClient:
         try:
             async with self.req_session.ws_connect(
                 self._url,
-                auth=self._auth,
                 heartbeat=WS_HEARTBEAT,
-                headers=WS_HEADERS,
+                headers=self._headers,
                 timeout=WS_TIMEOUT,
                 receive_timeout=self._hbwait + WS_HB_GRACE,
                 ssl=self.sslcontext,

--- a/pyisy/events/websocket.py
+++ b/pyisy/events/websocket.py
@@ -11,12 +11,7 @@ from xml.dom import minidom
 
 import aiohttp
 
-from ..connection import (
-    TLSVer,
-    basic_auth_header,
-    get_new_client_session,
-    get_sslcontext,
-)
+from ..connection import TLSVer, get_new_client_session, get_sslcontext
 from ..constants import (
     ACTION_KEY,
     ACTION_KEY_CHANGED,
@@ -88,7 +83,7 @@ class WebSocketClient:
         self._port = port
         self._username = username
         self._password = password
-        self._auth_header = basic_auth_header(self._username, self._password)
+        self._auth_header = aiohttp.encode_basic_auth(self._username, self._password)
         self._headers = {**WS_HEADERS, "Authorization": self._auth_header}
         self._webroot = webroot.rstrip("/")
         self._tls_ver = tls_ver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 
 dependencies = [
-    "aiohttp>=3.8.1",
+    "aiohttp>=3.14.0",
     "colorlog>=6.6.0",
 ]
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,9 +2,4 @@ pytest>=9.1.1
 pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
 syrupy>=5.5.3
-aioresponses>=0.7.9
-# aioresponses 0.7.9 (latest release) predates aiohttp 3.14's new required
-# ClientResponse `stream_writer` kwarg -- fix is open upstream but unreleased:
-# https://github.com/pnuckowski/aioresponses/pull/288. Remove this cap once
-# a released aioresponses version picks it up.
-aiohttp<3.14
+aiointercept>=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.8.1
+aiohttp>=3.14.0
 colorlog>=6.6.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "aiohttp>=3.8.1",
+        "aiohttp>=3.14.0",
         "colorlog>=6.6.0",
     ],
     keywords=["home automation", "isy", "isy994", "isy-994", "UDI"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,3 +233,9 @@ async def isy(fake_connection: FakeConnection) -> ISY:
     finally:
         # FakeConnection.close is an AsyncMock; shutdown() awaits it cleanly.
         await isy.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def intercept_ip_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route IP literal hosts through aiohttp's resolver for aiointercept."""
+    monkeypatch.setattr("aiointercept.core.is_ip_address", lambda _host: False)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 from pyisy.connection import (
     MAX_HTTP_CONNECTIONS_IOX,
@@ -82,7 +82,7 @@ async def test_request_401_raises_invalid_auth(conn: Connection) -> None:
     """A ``401 Unauthorized`` from the controller must surface as
     ``ISYInvalidAuthError`` rather than being silently retried."""
     url = conn.compile_url(["config"])
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=401, repeat=True)
         with pytest.raises(ISYInvalidAuthError):
             await conn.request(url)
@@ -94,13 +94,11 @@ async def test_test_connection_raises_when_config_unreachable(
     """``test_connection`` re-raises as ``ISYConnectionError`` when the
     config endpoint never responds — this is what ``ISY.initialize`` relies
     on to fail fast on bad creds / unreachable host."""
-    import aiohttp
-
     url = conn.compile_url(["config"])
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         # aiohttp.ClientError is caught by Connection.request and re-raised
         # as ISYConnectionError when retries=None (the test_connection path).
-        mocked.get(url, exception=aiohttp.ClientConnectionError("boom"))
+        mocked.get(url, exception=True)
         with pytest.raises(ISYConnectionError):
             await conn.test_connection()
 
@@ -109,7 +107,7 @@ async def test_request_404_returns_none_without_retry404(conn: Connection) -> No
     """A plain 404 (no ``retry404=True``) must return ``None`` without
     falling into the retry/backoff loop."""
     url = conn.compile_url(["nodes", "missing"])
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=404)
         result = await conn.request(url)
     assert result is None
@@ -119,7 +117,7 @@ async def test_request_404_with_ok404_returns_empty_string(conn: Connection) -> 
     """``ok404=True`` makes 404 a success indicator returning ``""`` — used by
     ``ping`` / ``get_network`` where a 404 means "feature not present"."""
     url = conn.compile_url(["network", "resources"])
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=404)
         result = await conn.request(url, ok404=True)
     assert result == ""
@@ -128,7 +126,7 @@ async def test_request_404_with_ok404_returns_empty_string(conn: Connection) -> 
 async def test_request_200_returns_body(conn: Connection) -> None:
     url = conn.compile_url(["config"])
     body = "<configuration><x/></configuration>"
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=200, body=body)
         result = await conn.request(url)
     assert result == body

--- a/tests/test_connection_extras.py
+++ b/tests/test_connection_extras.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 from pyisy.connection import (
     EMPTY_XML_RESPONSE,
@@ -121,7 +121,7 @@ async def test_ping_returns_true_on_response(conn: Connection) -> None:
     True if the controller responds at all (200 or 404 are both
     "alive")."""
     url = conn.compile_url(["ping"])
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=200, body="<x/>")
         assert await conn.ping() is True
 
@@ -131,8 +131,8 @@ async def test_ping_returns_false_on_unreachable(conn: Connection) -> None:
     so ping returns True. Use a connection error to simulate
     unreachable."""
     url = conn.compile_url(["ping"])
-    with aioresponses() as mocked:
-        mocked.get(url, exception=aiohttp.ClientConnectionError("boom"), repeat=True)
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mocked.get(url, exception=True, repeat=True)
         assert await conn.ping() is False
 
 
@@ -141,7 +141,7 @@ async def test_get_description_builds_desc_path(conn: Connection) -> None:
     ``/rest/`` and points at the UPnP-style ``/desc`` document. We
     stub ``request`` directly because the real ``request`` crashes on
     URLs that don't contain ``"rest"`` (filed as #488); once that's
-    fixed, this test can switch to an aioresponses round-trip."""
+    fixed, this test can switch to an aiointercept round-trip."""
     conn.request = AsyncMock(return_value="<root/>")
     result = await conn.get_description()
     url = conn.request.await_args.args[0]
@@ -252,9 +252,10 @@ async def test_request_503_falls_through_to_retry_and_returns_none(
     branch. With backoff exhausted (5 retries x small sleep), the
     function eventually returns None."""
     url = conn.compile_url(["status"])
-    with aioresponses() as mocked, patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
-        mocked.get(url, status=503, repeat=True)
-        result = await conn.request(url)
+    with patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
+        async with aiointercept(mock_external_urls=True) as mocked:
+            mocked.get(url, status=503, repeat=True)
+            result = await conn.request(url)
     assert result is None
 
 
@@ -264,9 +265,10 @@ async def test_request_empty_xml_response_falls_through_to_retry(
     """A 200 OK with ``<?xml ... ?>`` and nothing else is treated as
     "controller serving stale empty doc" and falls into retry/backoff."""
     url = conn.compile_url(["nodes"])
-    with aioresponses() as mocked, patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
-        mocked.get(url, status=200, body=EMPTY_XML_RESPONSE, repeat=True)
-        result = await conn.request(url)
+    with patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
+        async with aiointercept(mock_external_urls=True) as mocked:
+            mocked.get(url, status=200, body=EMPTY_XML_RESPONSE, repeat=True)
+            result = await conn.request(url)
     assert result is None
 
 
@@ -275,11 +277,8 @@ async def test_request_client_response_error_returns_none(conn: Connection) -> N
     are not retried — the controller is broken in a way that won't
     recover. Returns None unless ``retries=None``."""
     url = conn.compile_url(["nodes"])
-    with aioresponses() as mocked:
-        mocked.get(
-            url,
-            exception=aiohttp.ClientResponseError(request_info=None, history=(), status=502, message="bad"),
-        )
+    err = aiohttp.ClientResponseError(request_info=None, history=(), status=502, message="bad")
+    with patch.object(conn.req_session, "get", side_effect=err):
         result = await conn.request(url)
     assert result is None
 
@@ -296,16 +295,13 @@ async def test_request_client_response_error_with_ok404_returns_empty(
     into ``ok404=True`` (variable defs, network resources) should see
     that absorbed as ``""`` rather than an ERROR-level log + None."""
     url = conn.compile_url(["vars", "definitions", "1"])
-    with aioresponses() as mocked:
-        mocked.get(
-            url,
-            exception=aiohttp.ClientResponseError(
-                request_info=None,
-                history=(),
-                status=400,
-                message="Expected HTTP/, RTSP/ or ICE/:",
-            ),
-        )
+    err = aiohttp.ClientResponseError(
+        request_info=None,
+        history=(),
+        status=400,
+        message="Expected HTTP/, RTSP/ or ICE/:",
+    )
+    with patch.object(conn.req_session, "get", side_effect=err):
         result = await conn.request(url, ok404=True)
     assert result == ""
 
@@ -336,10 +332,11 @@ async def test_request_ssl_error_always_raises_connection_error(
         MagicMock(),
         ssl.SSLError(1, "[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol"),
     )
-    with aioresponses() as mocked:
-        mocked.get(url, exception=ssl_err)
-        with pytest.raises(ISYConnectionError, match="SSL/TLS error") as excinfo:
-            await conn.request(url)
+    with (
+        patch.object(conn.req_session, "get", side_effect=ssl_err),
+        pytest.raises(ISYConnectionError, match="SSL/TLS error") as excinfo,
+    ):
+        await conn.request(url)
     # Cause chain preserves the original aiohttp SSL error for
     # callers / log handlers that want to introspect it.
     assert isinstance(excinfo.value.__cause__, aiohttp.ClientSSLError)
@@ -358,10 +355,11 @@ async def test_request_ssl_error_raises_on_test_connection_path(
 
     url = conn.compile_url(["config"])
     ssl_err = aiohttp.ClientConnectorSSLError(MagicMock(), ssl.SSLError(1, "unsupported protocol"))
-    with aioresponses() as mocked:
-        mocked.get(url, exception=ssl_err)
-        with pytest.raises(ISYConnectionError, match="SSL/TLS error"):
-            await conn.request(url, retries=None)
+    with (
+        patch.object(conn.req_session, "get", side_effect=ssl_err),
+        pytest.raises(ISYConnectionError, match="SSL/TLS error"),
+    ):
+        await conn.request(url, retries=None)
 
 
 async def test_request_legacy_reneg_failure_enables_compat_and_retries() -> None:
@@ -393,12 +391,22 @@ async def test_request_legacy_reneg_failure_enables_compat_and_retries() -> None
                 "[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled",
             ),
         )
-        with aioresponses() as mocked:
+        real_get = https_conn.req_session.get
+        attempts = 0
+
+        def _get(*args: object, **kwargs: object) -> object:
             # First call: handshake refusal. Second call (after the
             # retry flips the flag): success.
-            mocked.get(url, exception=reneg_err)
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise reneg_err
+            return real_get(*args, **kwargs)
+
+        async with aiointercept(mock_external_urls=True) as mocked:
             mocked.get(url, status=200, body="<configuration/>")
-            result = await https_conn.request(url)
+            with patch.object(https_conn.req_session, "get", side_effect=_get):
+                result = await https_conn.request(url)
 
         assert result == "<configuration/>"
         assert https_conn.sslcontext.options & OP_LEGACY_SERVER_CONNECT
@@ -424,10 +432,11 @@ async def test_request_legacy_reneg_does_not_trigger_for_unrelated_ssl_errors() 
             MagicMock(),
             ssl.SSLError(1, "[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol"),
         )
-        with aioresponses() as mocked:
-            mocked.get(url, exception=proto_err)
-            with pytest.raises(ISYConnectionError, match="SSL/TLS error"):
-                await https_conn.request(url)
+        with (
+            patch.object(https_conn.req_session, "get", side_effect=proto_err),
+            pytest.raises(ISYConnectionError, match="SSL/TLS error"),
+        ):
+            await https_conn.request(url)
 
         # Flag must remain OFF — the user's security posture isn't
         # silently weakened on every SSL failure.
@@ -443,7 +452,7 @@ async def test_request_non_rest_url_does_not_crash(conn: Connection) -> None:
     a ``/desc`` URL that lacks that substring, so the happy path used to
     raise ``IndexError`` before the body could be returned."""
     url = "http://h:80/desc"
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=200, body="<root/>")
         result = await conn.request(url)
     assert result == "<root/>"
@@ -454,16 +463,17 @@ async def test_request_retry404_eventually_returns_none(conn: Connection) -> Non
     instead of returning immediately. After the retry budget is spent
     the result is still None."""
     url = conn.compile_url(["nodes", "X", "cmd", "DON"])
-    with aioresponses() as mocked, patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
-        mocked.get(url, status=404, repeat=True)
-        result = await conn.request(url, retry404=True)
+    with patch("pyisy.connection.RETRY_BACKOFF", [0, 0, 0, 0, 0]):
+        async with aiointercept(mock_external_urls=True) as mocked:
+            mocked.get(url, status=404, repeat=True)
+            result = await conn.request(url, retry404=True)
     assert result is None
 
 
 async def test_test_connection_returns_config_on_success(conn: Connection) -> None:
     url = conn.compile_url(["config"])
     body = "<configuration/>"
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(url, status=200, body=body)
         result = await conn.test_connection()
     assert result == body


### PR DESCRIPTION
`aiohttp.BasicAuth` and the request `auth` parameter are deprecated and will be removed in aiohttp 4.0. Their replacement, `aiohttp.encode_basic_auth()`, landed in aiohttp 3.14.0, so the aiohttp floor moves to 3.14 and this migration becomes a non-event.

Reaching 3.14 first meant replacing aioresponses, which is why `requirements-test.txt` still capped `aiohttp<3.14` (https://github.com/pnuckowski/aioresponses/pull/288 is still unreleased). [aiointercept](https://github.com/Polandia94/aiointercept) is a near drop-in replacement that serves the same mocks from a real local aiohttp server and supports 3.14, so the cap is gone.

Two test-side notes:

- aiointercept only produces `ClientConnectionError`, so the tests that inject a `ClientResponseError` or a `ClientConnectorSSLError` now patch the session instead of the mock. They cover the same branches.
- Bare IP addresses are not intercepted, so `conftest.py` gains an autouse fixture routing them through aiohttp's resolver.

All 448 tests pass on aiohttp 3.14.3.

I'm a bot, asked by @balloob to fix this because the deprecation warning shows up in Home Assistant CI.